### PR TITLE
small change to account for systemd sub-reapers.

### DIFF
--- a/src/wrench/services/compute/batch/BatchService.cpp
+++ b/src/wrench/services/compute/batch/BatchService.cpp
@@ -1602,12 +1602,14 @@ namespace wrench {
           {
             //now fork a process that sleeps until its parent is dead
             int nested_pid = fork();
+	    int parent_pid = getppid();
 
             if(nested_pid > 0) {
               //I am the parent, whose child fork exec'd batsched
             } else if (nested_pid == 0) {
               int ppid = getppid();
-              while (ppid != 1) {
+              while (ppid == parent_pid) {
+		sleep(1);
                 ppid = getppid();
               }
               //check if the child that forked batsched is still running


### PR DESCRIPTION
It turns out that orphaned processes are not automatically assumed to be attached to PID1 in GNU/Linux anymore. This small fix patches the errant processes problem, and also introduces a small tempo to make the active polling less resource consuming.
