### PR TITLE
Add capacity to retrieve host names on a per cluster basis

### DIFF
--- a/include/wrench/simgrid_S4U_util/S4U_Simulation.h
+++ b/include/wrench/simgrid_S4U_util/S4U_Simulation.h
@@ -12,6 +12,7 @@
 #define WRENCH_S4U_SIMULATION_H
 
 #include <simgrid/s4u.hpp>
+#include <simgrid/kernel/routing/ClusterZone.hpp>
 
 namespace wrench {
 
@@ -40,6 +41,7 @@ namespace wrench {
 				bool isInitialized();
         bool isPlatformSetup();
         std::vector<std::string> getAllHostnames();
+        std::map<std::string, std::vector<std::string>> getAllHostnamesByCluster();
         void shutdown();
 
 

--- a/include/wrench/simulation/Simulation.h
+++ b/include/wrench/simulation/Simulation.h
@@ -41,6 +41,7 @@ namespace wrench {
         void instantiatePlatform(std::string);
 
         std::vector<std::string> getHostnameList();
+        std::map<std::string, std::vector<std::string>> getHostnameListByCluster();
 
         bool hostExists(std::string hostname);
 

--- a/src/wrench/simgrid_S4U_util/S4U_Simulation.cpp
+++ b/src/wrench/simgrid_S4U_util/S4U_Simulation.cpp
@@ -109,6 +109,25 @@ namespace wrench {
       return hostname_list;
     }
 
+    std::map<std::string, std::vector<std::string>> S4U_Simulation::getAllHostnamesByCluster() {
+      std::map<std::string, std::vector<std::string>> result;
+      std::vector<simgrid::kernel::routing::ClusterZone*>clusters;
+
+      this->engine->getNetzoneByType<simgrid::kernel::routing::ClusterZone>(&clusters);
+      for (auto c : clusters) {
+        std::vector<simgrid::s4u::Host*> host_list;
+        c->getHosts(&host_list);
+        std::vector<std::string> hostname_list;
+        hostname_list.reserve(host_list.size());
+        for (auto h : host_list) {
+          hostname_list.push_back(std::string(h->getCname()));
+        }
+        result.insert({c->getName(), hostname_list});
+      }
+
+      return result;
+    }
+
     /**
      * @brief Determines whether a host exists for a given hostname
      * @param hostname: the hostname

--- a/src/wrench/simulation/Simulation.cpp
+++ b/src/wrench/simulation/Simulation.cpp
@@ -133,7 +133,15 @@ namespace wrench {
     std::vector<std::string> Simulation::getHostnameList() {
       return this->s4u_simulation->getAllHostnames();
     }
-
+    /**
+     * @brief Retrieve the list of names of all the hosts in each cluster composing the platform
+     *
+     * @return a map of (clustername, hostnames)
+     *
+     */
+    std::map<std::string, std::vector<std::string>> Simulation::getHostnameListByCluster() {
+      return this->s4u_simulation->getAllHostnamesByCluster();
+    }
     /**
      * @brief Check that a hostname exists in the platform
      *


### PR DESCRIPTION
This will allow wrench user to identify <cluster> among hosts. The rationale is that one usually declares a service for a set of computing resources that are grouped within a cluster.
Remark: this will only work from SimGrid 3.19 whose release date is March 20, 2018.