### PR TITLE
FileRegistry: Add an ADD_ENTRY, and REMOVE_ENTRY cost.

### DIFF
--- a/include/wrench/services/file_registry/FileRegistryService.h
+++ b/include/wrench/services/file_registry/FileRegistryService.h
@@ -42,6 +42,8 @@ namespace wrench {
 
         std::map<std::string, std::string> default_property_values = {
                 {FileRegistryServiceProperty::LOOKUP_COMPUTE_COST,                      "0.0"},
+                {FileRegistryServiceProperty::ADD_ENTRY_COMPUTE_COST,                   "0.0"},
+                {FileRegistryServiceProperty::REMOVE_ENTRY_COMPUTE_COST,                "0.0"},
         };
 
         std::map<std::string, double> default_messagepayload_values = {

--- a/include/wrench/services/file_registry/FileRegistryServiceProperty.h
+++ b/include/wrench/services/file_registry/FileRegistryServiceProperty.h
@@ -22,8 +22,13 @@ namespace wrench {
 
     public:
 
-        /** @brief The computational cost, in flops, of looking up entries for a file **/
+        /** 
+         * @brief The computational cost, in flops, of looking up, adding, and
+         * removing entries for a file
+         */
         DECLARE_PROPERTY_NAME(LOOKUP_COMPUTE_COST);
+        DECLARE_PROPERTY_NAME(ADD_ENTRY_COMPUTE_COST);
+        DECLARE_PROPERTY_NAME(REMOVE_ENTRY_COMPUTE_COST);
         
     };
 

--- a/src/wrench/services/file_registry/FileRegistryService.cpp
+++ b/src/wrench/services/file_registry/FileRegistryService.cpp
@@ -339,6 +339,10 @@ namespace wrench {
 
       } else if (auto msg = std::dynamic_pointer_cast<FileRegistryAddEntryRequestMessage>(message)) {
         addEntryToDatabase(msg->file, msg->location);
+
+        // Simulate an add overhead
+        S4U_Simulation::compute(getPropertyValueAsDouble(FileRegistryServiceProperty::ADD_ENTRY_COMPUTE_COST));
+
         S4U_Mailbox::dputMessage(msg->answer_mailbox,
                                  new FileRegistryAddEntryAnswerMessage(this->getMessagePayloadValue(
                                          FileRegistryServiceMessagePayload::ADD_ENTRY_ANSWER_MESSAGE_PAYLOAD)));
@@ -347,6 +351,10 @@ namespace wrench {
       } else if (auto msg = std::dynamic_pointer_cast<FileRegistryRemoveEntryRequestMessage>(message)) {
 
         bool success = removeEntryFromDatabase(msg->file, msg->location);
+
+        // Simulate a removal overhead
+        S4U_Simulation::compute(getPropertyValueAsDouble(FileRegistryServiceProperty::REMOVE_ENTRY_COMPUTE_COST));
+
         S4U_Mailbox::dputMessage(msg->answer_mailbox,
                                  new FileRegistryRemoveEntryAnswerMessage(success,
                                                                           this->getMessagePayloadValue(

--- a/src/wrench/services/file_registry/FileRegistryServiceProperty.cpp
+++ b/src/wrench/services/file_registry/FileRegistryServiceProperty.cpp
@@ -12,5 +12,7 @@
 namespace wrench {
 
     SET_PROPERTY_NAME(FileRegistryServiceProperty, LOOKUP_COMPUTE_COST);
+    SET_PROPERTY_NAME(FileRegistryServiceProperty, ADD_ENTRY_COMPUTE_COST);
+    SET_PROPERTY_NAME(FileRegistryServiceProperty, REMOVE_ENTRY_COMPUTE_COST);
 };
 

--- a/test/simulated_failures/link_failures/StorageServiceLinkFailuresTest.cpp
+++ b/test/simulated_failures/link_failures/StorageServiceLinkFailuresTest.cpp
@@ -375,7 +375,9 @@ void StorageServiceLinkFailuresTest::do_StorageServiceLinkFailureSimpleRandom_Te
     file_registry_service = simulation->add(
             new wrench::FileRegistryService("Host1",
                                             {
-                                                    {wrench::FileRegistryServiceProperty::LOOKUP_COMPUTE_COST, "0"}
+                                                    {wrench::FileRegistryServiceProperty::LOOKUP_COMPUTE_COST, "0"},
+                                                    {wrench::FileRegistryServiceProperty::ADD_ENTRY_COMPUTE_COST, "0"},
+                                                    {wrench::FileRegistryServiceProperty::REMOVE_ENTRY_COMPUTE_COST, "0"}
                                             },
                                             {
                                                     {wrench::FileRegistryServiceMessagePayload::ADD_ENTRY_REQUEST_MESSAGE_PAYLOAD, message_payload},


### PR DESCRIPTION
I ran a `git grep LOOKUP_COMPUTE_COST` and added the necessary changes to all files that showed up in the grep. I assumed we wanted a default to `"0.0"` here as well.