### PR TITLE
Adding a "CompoundStorageService"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,9 @@ set(HEADER_FILES
         include/wrench/services/storage/simple/SimpleStorageServiceNonBufferized.h
         include/wrench/services/storage/simple/SimpleStorageServiceMessagePayload.h
         include/wrench/services/storage/simple/SimpleStorageServiceProperty.h
+        include/wrench/services/storage/compound/CompoundStorageService.h
+        include/wrench/services/storage/compound/CompoundStorageServiceProperty.h
+        include/wrench/services/storage/compound/CompoundStorageServiceMessagePayload.h
         include/wrench/services/storage/storage_helpers/FileLocation.h
         include/wrench/services/memory/Block.h
         include/wrench/services/memory/MemoryManager.h
@@ -300,6 +303,9 @@ set(SOURCE_FILES
         src/wrench/services/storage/simple/SimpleStorageServiceNonBufferized.cpp
         src/wrench/services/storage/simple/SimpleStorageServiceMessagePayload.cpp
         src/wrench/services/storage/simple/SimpleStorageServiceProperty.cpp
+        src/wrench/services/storage/compound/CompoundStorageService.cpp
+        src/wrench/services/storage/compound/CompoundStorageServiceProperty.cpp
+        src/wrench/services/storage/compound/CompoundStorageServiceMessagePayload.cpp
         src/wrench/services/storage/storage_helper_classes/FileLocation.cpp
         src/wrench/services/storage/storage_helper_classes/FileTransferThread.cpp
         include/wrench/services/storage/storage_helpers/FileTransferThreadMessage.h
@@ -429,6 +435,7 @@ set(TEST_FILES
         test/services/helper_services/AlarmTest.cpp
         test/services/storage_services/XRootDStorageService/XRootDStorageServiceBasicFunctionalTest.cpp
         test/services/storage_services/XRootDStorageService/XRootDStorageServiceFullFunctionalTest.cpp
+        test/services/storage_services/CompoundStorageService/CompoundStorageServiceFunctionalTest.cpp
         test/wms/WMSTest.cpp
         test/wms/MultipleWMSTest.cpp
         test/services/compute_services/virtualized_cluster/VirtualizedClusterServiceTest.cpp

--- a/include/wrench.h
+++ b/include/wrench.h
@@ -16,6 +16,7 @@
 #include "wrench/services/compute/bare_metal/BareMetalComputeService.h"
 #include "wrench/services/compute/bare_metal/BareMetalComputeServiceProperty.h"
 #include "wrench/services/storage/simple/SimpleStorageService.h"
+#include "wrench/services/storage/compound/CompoundStorageService.h"
 #include "wrench/services/storage/simple/SimpleStorageServiceProperty.h"
 #include "wrench/services/storage/xrootd/Deployment.h"
 #include "wrench/services/storage/xrootd/XRootDProperty.h"

--- a/include/wrench/services/storage/StorageService.h
+++ b/include/wrench/services/storage/StorageService.h
@@ -134,6 +134,7 @@ namespace wrench {
         friend class FileTransferThread;
         friend class SimpleStorageServiceNonBufferized;
         friend class SimpleStorageServiceBufferized;
+        friend class CompoundStorageService;
 
         static void stageFile(const std::shared_ptr<FileLocation> &location);
 

--- a/include/wrench/services/storage/compound/CompoundStorageService.h
+++ b/include/wrench/services/storage/compound/CompoundStorageService.h
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2017-2020. The WRENCH Team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef WRENCH_COMPOUNDSTORAGESERVICE_H
+#define WRENCH_COMPOUNDSTORAGESERVICE_H
+
+#include "wrench/services/storage/StorageService.h"
+#include "wrench/services/storage/StorageServiceMessage.h"
+#include "wrench/services/memory/MemoryManager.h"
+#include "wrench/simgrid_S4U_util/S4U_PendingCommunication.h"
+#include "wrench/services/storage/compound/CompoundStorageServiceProperty.h"
+#include "wrench/services/storage/compound/CompoundStorageServiceMessagePayload.h"
+
+namespace wrench {
+
+    using StorageSelectionStrategyCallback = std::function<std::shared_ptr<FileLocation>(
+        const std::shared_ptr<DataFile>&, 
+        const std::set<std::shared_ptr<StorageService>>&, 
+        const std::map<std::shared_ptr<DataFile>, std::shared_ptr<FileLocation>>&
+    )>;
+
+    /**
+     * @brief An abstract storage service which holds a collection of concrete storage services (eg. 
+     *        SimpleStorageServices). It does not provide direct access to any storage resource.
+     *        It is meant to be used as a way to postpone the selection of a storage service for a file 
+     *        action (read, write, copy, etc) until a later time in the simulation, rather than during
+     *        job definition. A typical use for the CompoundStorageService is to select a definitive
+     *        SimpleStorageService for each action of a job during its scheduling in a BatchScheduler class.
+     *        This service is able to receive and handle the same messages as any standard storage service 
+     *        (File Read/Write/Delete/Copy/Lookup requests), but will always answer that it is unable to 
+     *        process any of these requests, which should be addressed directly to the correct underlying 
+     *        storage service. (A possible future patch could give it the ability to automatically forward 
+     *        said request to one of the underlying storage services).
+     */
+    class CompoundStorageService : public StorageService {
+    
+    public:
+
+        CompoundStorageService(const std::string &hostname,
+                               std::set<std::shared_ptr<StorageService>> storage_services,
+                               WRENCH_PROPERTY_COLLECTION_TYPE property_list = {},
+                               WRENCH_MESSAGE_PAYLOADCOLLECTION_TYPE messagepayload_list = {}); 
+
+        CompoundStorageService(const std::string &hostname,
+                               std::set<std::shared_ptr<StorageService>> storage_services,
+                               StorageSelectionStrategyCallback storage_selection,
+                               WRENCH_PROPERTY_COLLECTION_TYPE property_list = {},
+                               WRENCH_MESSAGE_PAYLOADCOLLECTION_TYPE messagepayload_list = {});
+ 
+        double getFileLastWriteDate(const std::shared_ptr<FileLocation> &location) override;
+
+        double getLoad() override;
+
+        // Overload StorageService's implementation.
+        std::map<std::string, double> getTotalSpace();
+
+        // Overload StorageService's implementation.
+        std::map<std::string, double> getFreeSpace();
+        
+        // Overload StorageService's implementation.
+        void setScratch();
+
+        /**
+         * @brief Method to return the collection of known StorageServices
+         */
+        std::set<std::shared_ptr<StorageService>>& getAllServices();
+
+        std::shared_ptr<FileLocation> lookupFileLocation(const std::shared_ptr<DataFile> &file);
+
+        std::shared_ptr<FileLocation> lookupFileLocation(const std::shared_ptr<FileLocation> &location);
+
+    protected:
+
+        CompoundStorageService(const std::string &hostname, 
+                               std::set<std::shared_ptr<StorageService>> storage_services,
+                               StorageSelectionStrategyCallback storage_selection,
+                               bool storage_selection_user_provided,
+                               WRENCH_PROPERTY_COLLECTION_TYPE property_list,
+                               WRENCH_MESSAGE_PAYLOADCOLLECTION_TYPE messagepayload_list,
+                               const std::string &suffix);
+
+        WRENCH_PROPERTY_COLLECTION_TYPE default_property_values = {
+                {CompoundStorageServiceProperty::STORAGE_SELECTION_METHOD, "external"},
+                {CompoundStorageServiceProperty::CACHING_BEHAVIOR, "NONE"},
+        };
+
+        /** @brief Default message payload values 
+         *         Some values are set to zero because in the current implementation, it is expected
+         *         that the CompoundStorageService will always immediately refuse / reject such
+         *         requests, with minimum cost to the user.
+         */
+        WRENCH_MESSAGE_PAYLOADCOLLECTION_TYPE default_messagepayload_values = {
+                {CompoundStorageServiceMessagePayload::STOP_DAEMON_MESSAGE_PAYLOAD, 1024},
+                {CompoundStorageServiceMessagePayload::DAEMON_STOPPED_MESSAGE_PAYLOAD, 1024},
+                {CompoundStorageServiceMessagePayload::FREE_SPACE_REQUEST_MESSAGE_PAYLOAD, 0},
+                {CompoundStorageServiceMessagePayload::FILE_DELETE_REQUEST_MESSAGE_PAYLOAD, 0},
+                {CompoundStorageServiceMessagePayload::FILE_DELETE_ANSWER_MESSAGE_PAYLOAD, 0},
+                {CompoundStorageServiceMessagePayload::FILE_LOOKUP_REQUEST_MESSAGE_PAYLOAD, 0},
+                {CompoundStorageServiceMessagePayload::FILE_LOOKUP_ANSWER_MESSAGE_PAYLOAD, 0},
+                {CompoundStorageServiceMessagePayload::FILE_COPY_REQUEST_MESSAGE_PAYLOAD, 0},
+                {CompoundStorageServiceMessagePayload::FILE_COPY_ANSWER_MESSAGE_PAYLOAD, 0},
+                {CompoundStorageServiceMessagePayload::FILE_READ_REQUEST_MESSAGE_PAYLOAD, 0},
+                {CompoundStorageServiceMessagePayload::FILE_READ_ANSWER_MESSAGE_PAYLOAD, 0},
+                {CompoundStorageServiceMessagePayload::FILE_WRITE_REQUEST_MESSAGE_PAYLOAD, 0},
+                {CompoundStorageServiceMessagePayload::FILE_WRITE_ANSWER_MESSAGE_PAYLOAD, 0},
+        };
+
+        static unsigned long getNewUniqueNumber();
+
+        bool processStopDaemonRequest(simgrid::s4u::Mailbox *ack_mailbox);
+
+        virtual bool hasFile(const std::shared_ptr<DataFile> &file, const std::string &path) override;
+
+    private:
+        friend class Simulation;
+
+        int main() override;
+
+        std::shared_ptr<FileLocation> lookupOrDesignateStorageService(const std::shared_ptr<DataFile> concrete_file_location);
+
+        std::shared_ptr<FileLocation> lookupOrDesignateStorageService(const std::shared_ptr<FileLocation> location);
+
+        bool processNextMessage(SimulationMessage *message);
+
+        bool processFileDeleteRequest(StorageServiceFileDeleteRequestMessage *msg);
+
+        bool processFileLookupRequest(StorageServiceFileLookupRequestMessage* msg);
+
+        bool processFileCopyRequest(StorageServiceFileCopyRequestMessage* msg);
+
+        bool processFileWriteRequest(StorageServiceFileWriteRequestMessage* msg);
+
+        bool processFileReadRequest(StorageServiceFileReadRequestMessage* msg);
+        
+        std::set<std::shared_ptr<StorageService>> storage_services = {};
+
+        std::map<std::shared_ptr<DataFile>, std::shared_ptr<FileLocation>> file_location_mapping = {};
+
+        StorageSelectionStrategyCallback storage_selection;
+
+        bool isStorageSelectionUserProvided;
+
+    };
+
+};// namespace wrench
+
+#endif //WRENCH_COMPOUNDSTORAGESERVICE_H

--- a/include/wrench/services/storage/compound/CompoundStorageService.h
+++ b/include/wrench/services/storage/compound/CompoundStorageService.h
@@ -39,9 +39,7 @@ namespace wrench {
      *        said request to one of the underlying storage services).
      */
     class CompoundStorageService : public StorageService {
-    
     public:
-
         CompoundStorageService(const std::string &hostname,
                                std::set<std::shared_ptr<StorageService>> storage_services,
                                WRENCH_PROPERTY_COLLECTION_TYPE property_list = {},
@@ -74,9 +72,8 @@ namespace wrench {
         std::shared_ptr<FileLocation> lookupFileLocation(const std::shared_ptr<DataFile> &file);
 
         std::shared_ptr<FileLocation> lookupFileLocation(const std::shared_ptr<FileLocation> &location);
-
+        
     protected:
-
         CompoundStorageService(const std::string &hostname, 
                                std::set<std::shared_ptr<StorageService>> storage_services,
                                StorageSelectionStrategyCallback storage_selection,
@@ -115,7 +112,7 @@ namespace wrench {
 
         bool processStopDaemonRequest(simgrid::s4u::Mailbox *ack_mailbox);
 
-        virtual bool hasFile(const std::shared_ptr<DataFile> &file, const std::string &path) override;
+        bool hasFile(const std::shared_ptr<DataFile> &file, const std::string &path) override;
 
     private:
         friend class Simulation;
@@ -145,7 +142,6 @@ namespace wrench {
         StorageSelectionStrategyCallback storage_selection;
 
         bool isStorageSelectionUserProvided;
-
     };
 
 };// namespace wrench

--- a/include/wrench/services/storage/compound/CompoundStorageServiceMessagePayload.h
+++ b/include/wrench/services/storage/compound/CompoundStorageServiceMessagePayload.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2017. The WRENCH Team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+
+#ifndef WRENCH_COMPOUNDSTORAGESERVICEMESSAGEPAYLOAD_H
+#define WRENCH_COMPOUNDSTORAGESERVICEMESSAGEPAYLOAD_H
+
+#include "wrench/services/storage/StorageServiceMessagePayload.h"
+
+namespace wrench {
+
+    /**
+    * @brief Configurable message payloads for a CompoundStorageService
+    */
+    class CompoundStorageServiceMessagePayload : public StorageServiceMessagePayload {
+    public:
+    };
+
+};// namespace wrench
+
+
+#endif//WRENCH_COMPOUNDSTORAGESERVICEMESSAGEPAYLOAD_H

--- a/include/wrench/services/storage/compound/CompoundStorageServiceProperty.h
+++ b/include/wrench/services/storage/compound/CompoundStorageServiceProperty.h
@@ -19,7 +19,6 @@ namespace wrench {
     * @brief Configurable properties for a CompoundStorageService
     */
     class CompoundStorageServiceProperty : public StorageServiceProperty {
-
     public:
         /** @brief Property that defines how the underlying storage is selected:
          *         So far the only option is to have an external process that 

--- a/include/wrench/services/storage/compound/CompoundStorageServiceProperty.h
+++ b/include/wrench/services/storage/compound/CompoundStorageServiceProperty.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2017. The WRENCH Team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+
+#ifndef WRENCH_COMPOUNDSTORAGESERVICEPROPERTY_H
+#define WRENCH_COMPOUNDSTORAGESERVICEPROPERTY_H
+
+#include "wrench/services/storage/StorageServiceProperty.h"
+
+namespace wrench {
+
+    /**
+    * @brief Configurable properties for a CompoundStorageService
+    */
+    class CompoundStorageServiceProperty : public StorageServiceProperty {
+
+    public:
+        /** @brief Property that defines how the underlying storage is selected:
+         *         So far the only option is to have an external process that 
+         *         update actions in job (property value: "external"), with the
+         *         CompoundStorageService being passive. A future option would be
+         *         to have the CSS take the decision upon receiving an IO request.
+         */
+        DECLARE_PROPERTY_NAME(STORAGE_SELECTION_METHOD);
+    };
+
+};// namespace wrench
+
+
+#endif//WRENCH_COMPOUNDSTORAGESERVICEPROPERTY_H

--- a/include/wrench/services/storage/storage_helpers/FileLocation.h
+++ b/include/wrench/services/storage/storage_helpers/FileLocation.h
@@ -51,8 +51,10 @@ namespace wrench {
 
         std::shared_ptr<DataFile> getFile();
         std::shared_ptr<StorageService> getStorageService();
+        std::shared_ptr<StorageService> setStorageService(std::shared_ptr<StorageService> ss);
         std::shared_ptr<StorageService> getServerStorageService();
         std::string getMountPoint();
+        std::string setMountPoint(std::string mount_point);
         std::string getAbsolutePathAtMountPoint();
         std::string getFullAbsolutePath();
         bool isScratch() const;

--- a/src/wrench/services/storage/compound/CompoundStorageService.cpp
+++ b/src/wrench/services/storage/compound/CompoundStorageService.cpp
@@ -27,7 +27,6 @@ namespace wrench {
         const std::shared_ptr<DataFile>& file, 
         const std::set<std::shared_ptr<StorageService>>& resources,
         const std::map<std::shared_ptr<DataFile>, std::shared_ptr<FileLocation>>& mapping) {
-
         return nullptr;
     }
 
@@ -73,7 +72,6 @@ namespace wrench {
                 WRENCH_MESSAGE_PAYLOADCOLLECTION_TYPE messagepayload_list,
                 const std::string &suffix) : StorageService(hostname, 
                     "compound_storage" + suffix) {
-
             this->setProperties(this->default_property_values, std::move(property_list));
             this->setMessagePayloads(this->default_messagepayload_values, std::move(messagepayload_list));
 
@@ -115,7 +113,6 @@ namespace wrench {
      * @return 0 on termination
      */
     int CompoundStorageService::main() {
-
         //TODO: Use another colour?
         TerminalOutput::setThisProcessLoggingColor(TerminalOutput::COLOR_CYAN);
         std::string message = "Compound Storage Service " + this->getName() + "  starting on host " + this->getHostname();
@@ -138,7 +135,6 @@ namespace wrench {
         simgrid::s4u::CommPtr comm_ptr;
         std::unique_ptr<SimulationMessage> simulation_message;
         while (true) {
-
             S4U_Simulation::computeZeroFlop();
 
             // Create an async recv if needed
@@ -191,7 +187,6 @@ namespace wrench {
      * @return false if the daemon should terminate
      */
     bool CompoundStorageService::processNextMessage(SimulationMessage *message) {
-
         WRENCH_INFO("Got a [%s] message", message->getName().c_str());
 
         if (auto msg = dynamic_cast<ServiceStopDaemonMessage *>(message)) {
@@ -224,8 +219,7 @@ namespace wrench {
      * 
      * @return A shared_ptr on a FileLocation if the DataFile is known to the CompoundStorageService or nullptr if it's not.
      */
-    std::shared_ptr<FileLocation> CompoundStorageService::lookupFileLocation(const std::shared_ptr<DataFile> &file) {
-        
+    std::shared_ptr<FileLocation> CompoundStorageService::lookupFileLocation(const std::shared_ptr<DataFile> &file) { 
         WRENCH_DEBUG("lookupFileLocation: For file %s", file->getID().c_str());
 
         if (this->file_location_mapping.find(file) == this->file_location_mapping.end()) {
@@ -261,7 +255,6 @@ namespace wrench {
      *          or nullptr if it's not.
      */
     std::shared_ptr<FileLocation> CompoundStorageService::lookupOrDesignateStorageService(const std::shared_ptr<DataFile> concrete_file_location) {
-
         if (this->lookupFileLocation(concrete_file_location)) {
             WRENCH_DEBUG("lookupOrDesignateStorageService: File %s already known by CSS", concrete_file_location->getID().c_str());
             return this->file_location_mapping[concrete_file_location];
@@ -305,10 +298,8 @@ namespace wrench {
      * @return true if this process should keep running
      */
     bool CompoundStorageService::processFileDeleteRequest(StorageServiceFileDeleteRequestMessage *msg) {
-
         auto designated_location = this->lookupFileLocation(msg->location);
         if (!designated_location) {
-
             WRENCH_WARN("processFileDeleteRequest: Unable to find file %s", 
                         msg->location->getFile()->getID().c_str());
             try {        
@@ -346,10 +337,8 @@ namespace wrench {
      * @return true if this process should keep running
      */
     bool CompoundStorageService::processFileLookupRequest(StorageServiceFileLookupRequestMessage* msg) {
-        
         auto designated_location = this->lookupFileLocation(msg->location);
         if (!designated_location) {
-            
             WRENCH_WARN("processFileLookupRequest: Unable to find file %s", msg->location->getFile()->getID().c_str());
             // Abort because we don't know the file (it should have been written or copied somewhere before the lookup happens)
             try {
@@ -379,7 +368,6 @@ namespace wrench {
         );
 
         return true;
-
     }
 
     /**
@@ -389,7 +377,6 @@ namespace wrench {
      * @return true if this process should keep running
      */
     bool CompoundStorageService::processFileCopyRequest(StorageServiceFileCopyRequestMessage *msg) {
-
         // If source location references a CSS, it must already be known to the CSS
         auto final_src = msg->src;
         if (std::dynamic_pointer_cast<CompoundStorageService>(msg->src->getStorageService())) {
@@ -403,7 +390,6 @@ namespace wrench {
 
         // Error case - src
         if (!final_src) {
-           
             WRENCH_WARN("processFileCopyRequest: Source %s is a CompoundStorageService and file doesn't exist yet.", 
                         msg->src->getStorageService()->getName().c_str());
             try {
@@ -433,7 +419,6 @@ namespace wrench {
 
         // Error case - dst
         if (!final_dst) {
-
             WRENCH_WARN("processFileCopyRequest: Destination file %s not found or not enough space left",
                         msg->dst->getFile()->getID().c_str());
 
@@ -507,10 +492,8 @@ namespace wrench {
      * @return true if this process should keep running
      */
     bool CompoundStorageService::processFileWriteRequest(StorageServiceFileWriteRequestMessage* msg) {
-
         auto designated_location = this->lookupOrDesignateStorageService(msg->location);
         if (!designated_location) {
-
             WRENCH_WARN("processFileWriteRequest: Destination file %s not found or not enough space left",
                         msg->location->getFile()->getID().c_str());
             try {
@@ -551,10 +534,8 @@ namespace wrench {
      * @return true if this process should keep running
      */
     bool CompoundStorageService::processFileReadRequest(StorageServiceFileReadRequestMessage* msg) {        
-        
         auto designated_location = this->lookupFileLocation(msg->location);
         if (!designated_location) {
-
             WRENCH_WARN("processFileReadRequest: file %s not found", msg->location->getFile()->getID().c_str());
             try {
                 S4U_Mailbox::dputMessage(
@@ -571,7 +552,6 @@ namespace wrench {
             } catch (wrench::ExecutionException &e) {}
 
             return true;
-
         }
 
         WRENCH_DEBUG("processFileReadRequest: Going to read file %s on storage service %s, at path %s", 
@@ -613,7 +593,6 @@ namespace wrench {
      * @return A map of service name and total capacity of all disks for each service.
      */
     std::map<std::string, double> CompoundStorageService::getTotalSpace() {
-
         WRENCH_INFO("CompoundStorageService::getTotalSpace");
         std::map<std::string, double> to_return;
         for (const auto & service : this->storage_services) {
@@ -637,20 +616,17 @@ namespace wrench {
      *
      */
     std::map<std::string, double> CompoundStorageService::getFreeSpace() {
-
         WRENCH_DEBUG("CompoundStorageService::getFreeSpace Forwarding request to internal services");
 
         std::map<std::string, double> to_return = {}; 
         std::map<std::string, simgrid::s4u::Mailbox*> mailboxes = {};
 
         for (const auto & service : this->storage_services) {
-            
             auto free_space = service->getFreeSpace();
 
             to_return[service->getName()] = std::accumulate(free_space.begin(), free_space.end(), 0, 
                                                           [](const std::size_t previous, const auto& element){return previous + element.second;}
             );
-
         }
 
         return to_return;
@@ -688,7 +664,6 @@ namespace wrench {
      *
      */
     double CompoundStorageService::getFileLastWriteDate(const std::shared_ptr<FileLocation> &location) {
-
         if (!this->lookupFile(location)) {
             throw std::invalid_argument("CompoundStorageService::getFileLastWriteDate(): File not known to the CompoundStorageService. Unable to forward to underlying StorageService");
         }
@@ -699,7 +674,6 @@ namespace wrench {
         } else {
             throw std::logic_error("CompoundStorageService::getFileLastWriteDate(): File known, but allocated on StorageService that doesn't implement getFileLastWriteDate()");
         }
-
     }
 
     bool CompoundStorageService::hasFile(const std::shared_ptr<DataFile> &file, const std::string &path) {

--- a/src/wrench/services/storage/compound/CompoundStorageService.cpp
+++ b/src/wrench/services/storage/compound/CompoundStorageService.cpp
@@ -1,0 +1,750 @@
+#include <wrench/services/storage/compound/CompoundStorageService.h>
+#include <wrench/services/ServiceMessage.h>
+#include <wrench/services/storage/simple/SimpleStorageService.h>
+#include "wrench/services/storage/StorageServiceMessage.h"
+#include <wrench/services/storage/StorageServiceMessagePayload.h>
+#include <wrench/simgrid_S4U_util/S4U_Mailbox.h>
+#include <wrench/failure_causes/FileNotFound.h>
+#include <wrench/failure_causes/StorageServiceNotEnoughSpace.h>
+#include <wrench/failure_causes/NotAllowed.h>
+#include <wrench/exceptions/ExecutionException.h>
+#include <wrench/logging/TerminalOutput.h>
+
+WRENCH_LOG_CATEGORY(wrench_core_compound_storage_system,
+                    "Log category for Compound Storage Service");
+
+namespace wrench { 
+
+
+    /** 
+     *  @brief Default StorageSelectionStrategyCallback: strategy used by the CompoundStorageService 
+     *         when no strategy is provided at instanciation. By default, it returns a nullptr, which 
+     *         trigger any request message processing function in CompoundStorageServer to answer negatively.
+     * 
+     *  @return nullptr (instead of a valid FileLocation)
+    */
+    std::shared_ptr<FileLocation> nullptrStorageServiceSelection(
+        const std::shared_ptr<DataFile>& file, 
+        const std::set<std::shared_ptr<StorageService>>& resources,
+        const std::map<std::shared_ptr<DataFile>, std::shared_ptr<FileLocation>>& mapping) {
+
+        return nullptr;
+    }
+
+
+    /** 
+     *  @brief Constructor for the case where no request message (for I/O operations) should ever reach
+     *         the CompoundStorageService. This use case suppose that any action making use of a FileLocation
+     *         referencing this CompoundStorageService will be intercepted before its execution (in a scheduler
+     *         for instance) and updated with one of the StorageServices known to this CompoundStorageService.
+    */
+    CompoundStorageService::CompoundStorageService(const std::string &hostname,
+                                                   std::set<std::shared_ptr<StorageService>> storage_services,
+                                                   WRENCH_PROPERTY_COLLECTION_TYPE property_list,
+                                                   WRENCH_MESSAGE_PAYLOADCOLLECTION_TYPE messagepayload_list) :
+            CompoundStorageService(hostname, storage_services, nullptrStorageServiceSelection, false,
+                                   property_list, messagepayload_list, "_" + std::to_string(getNewUniqueNumber())) {};
+
+
+    /** 
+     *  @brief Constructor for the case where the user provides a callback (StorageSelectionStrategyCallback) 
+     *         which will be used by the CompoundStorageService any time it receives a file write or file copy 
+     *         request, in order to determine which underlying StorageService to use for the (potentially) new
+     *         file in the request. 
+     *         Note that nothing prevents the user from also intercepting some actions (see use case for other 
+     *         constructor), but resulting behaviour is undefined.
+    */
+    CompoundStorageService::CompoundStorageService(const std::string &hostname,
+                                                   std::set<std::shared_ptr<StorageService>> storage_services,
+                                                   StorageSelectionStrategyCallback storage_selection,
+                                                   WRENCH_PROPERTY_COLLECTION_TYPE property_list,
+                                                   WRENCH_MESSAGE_PAYLOADCOLLECTION_TYPE messagepayload_list) :
+            CompoundStorageService(hostname, storage_services, storage_selection, true, property_list, messagepayload_list, 
+                                   "_" + std::to_string(getNewUniqueNumber())) {};
+
+
+
+    CompoundStorageService::CompoundStorageService(
+                const std::string &hostname, 
+                std::set<std::shared_ptr<StorageService>> storage_services,
+                StorageSelectionStrategyCallback storage_selection,
+                bool storage_selection_user_provided,
+                WRENCH_PROPERTY_COLLECTION_TYPE property_list,
+                WRENCH_MESSAGE_PAYLOADCOLLECTION_TYPE messagepayload_list,
+                const std::string &suffix) : StorageService(hostname, 
+                    "compound_storage" + suffix) {
+
+            this->setProperties(this->default_property_values, std::move(property_list));
+            this->setMessagePayloads(this->default_messagepayload_values, std::move(messagepayload_list));
+
+            if (storage_services.empty()) {
+                throw std::invalid_argument("Got an empty list of SimpleStorageServices for CompoundStorageService."
+                                            "Must specify at least one valid SimpleStorageService");
+            }
+
+            if (std::any_of(storage_services.begin(), storage_services.end(), [](const auto& elem){ return elem == NULL; })) {
+                throw std::invalid_argument("One of the SimpleStorageServices provided is not initialized");
+            }
+
+            /* // This should eventually be allowed, currently trying to fix it.
+            if (std::any_of(storage_services.begin(), storage_services.end(), [](const auto& elem){ return elem->isBufferized(); })) {
+                throw std::invalid_argument("CompoundStorageService can't deal with bufferized StorageServices");
+            }
+            */
+
+            // CSS should be non-bufferized, as it actually doesn't copy / transfer anything
+            // and this allows it to receive message requests for copy (otherwise, src storage service might receive it)
+            this->buffer_size = 0;
+            this->storage_services = storage_services;
+            this->storage_selection = storage_selection;
+            this->isStorageSelectionUserProvided = storage_selection_user_provided;
+            
+            // Dummy logical file system
+            this->file_systems[LogicalFileSystem::DEV_NULL] = LogicalFileSystem::createLogicalFileSystem(
+                this->getHostname(), 
+                this, 
+                LogicalFileSystem::DEV_NULL, 
+                this->getPropertyValueAsString(wrench::StorageServiceProperty::CACHING_BEHAVIOR)
+            );
+        }
+
+
+    /**
+     * @brief Main method of the daemon
+     *
+     * @return 0 on termination
+     */
+    int CompoundStorageService::main() {
+
+        //TODO: Use another colour?
+        TerminalOutput::setThisProcessLoggingColor(TerminalOutput::COLOR_CYAN);
+        std::string message = "Compound Storage Service " + this->getName() + "  starting on host " + this->getHostname();
+        WRENCH_INFO("%s", message.c_str());
+
+        // Init file system. There is always only one built-in LogicalFilesystem, with a DEV_NULL mount point.
+        for (auto const& fs: this->file_systems) { fs.second->init(); };
+
+        WRENCH_INFO("Registered underlying storage services:");
+        for (const auto &ss: this->storage_services) {
+            message = " - " + ss->process_name + " on " + ss->getHostname();
+            WRENCH_INFO("%s", message.c_str());
+            for (const auto &mnt: ss->getMountPoints()) {
+                WRENCH_INFO("  - %s", mnt.c_str());
+            }
+        }
+
+        /** Main loop **/
+        bool comm_ptr_has_been_posted = false;
+        simgrid::s4u::CommPtr comm_ptr;
+        std::unique_ptr<SimulationMessage> simulation_message;
+        while (true) {
+
+            S4U_Simulation::computeZeroFlop();
+
+            // Create an async recv if needed
+            if (not comm_ptr_has_been_posted) {
+                try {
+                    comm_ptr = this->mailbox->get_async<void>((void **) (&(simulation_message)));
+                } catch (simgrid::NetworkFailureException &e) {
+                    // oh well
+                    continue;
+                }
+                comm_ptr_has_been_posted = true;
+            }
+
+            // Create all activities to wait on (only emplace the communicator)
+            std::vector<simgrid::s4u::ActivityPtr> pending_activities;
+            pending_activities.emplace_back(comm_ptr);
+
+            // Wait one activity (communication in this case) to complete
+            int finished_activity_index;
+            try {
+                finished_activity_index = (int) simgrid::s4u::Activity::wait_any(pending_activities);
+            } catch (simgrid::NetworkFailureException &e) {
+                comm_ptr_has_been_posted = false;
+                continue;
+            } catch (std::exception &e) {
+                continue;
+            }
+
+            // It's a communication
+            if (finished_activity_index == 0) {
+                comm_ptr_has_been_posted = false;
+                if (not processNextMessage(simulation_message.get())) break;
+            } else if (finished_activity_index == -1) {
+                throw std::runtime_error("wait_any() returned -1. Not sure what to do with this. ");
+            }
+        }
+
+        WRENCH_INFO("Compound Storage Service %s on host %s cleanly terminating!",
+                    this->getName().c_str(),
+                    S4U_Simulation::getHostName().c_str());
+
+        return 0;
+    }
+
+    /**
+     * @brief Process a received control message
+     *
+     * @throw std::runtime_error when receiving an unexpected message type.
+     * 
+     * @return false if the daemon should terminate
+     */
+    bool CompoundStorageService::processNextMessage(SimulationMessage *message) {
+
+        WRENCH_INFO("Got a [%s] message", message->getName().c_str());
+
+        if (auto msg = dynamic_cast<ServiceStopDaemonMessage *>(message)) {
+            return processStopDaemonRequest(msg->ack_mailbox);
+
+        } else if (auto msg = dynamic_cast<StorageServiceFileDeleteRequestMessage *>(message)) {
+            return processFileDeleteRequest(msg);
+
+        } else if (auto msg = dynamic_cast<StorageServiceFileLookupRequestMessage *>(message)) {
+            return processFileLookupRequest(msg);
+
+        } else if (auto msg = dynamic_cast<StorageServiceFileWriteRequestMessage *>(message)) {
+            return processFileWriteRequest(msg);
+
+        } else if (auto msg = dynamic_cast<StorageServiceFileReadRequestMessage *>(message)) {
+            return processFileReadRequest(msg);
+
+        } else if (auto msg = dynamic_cast<StorageServiceFileCopyRequestMessage *>(message)) {
+            return processFileCopyRequest(msg);
+
+        } else {
+            throw std::runtime_error(
+                "CompoundStorageService::processNextMessage(): Unexpected [" + message->getName() + "] message." + 
+                "This is only an abstraction layer and it can't be used as an actual storage service");
+        }
+    }
+
+    /**
+     * @brief Lookup for a DataFile in the internal file mapping of the CompoundStorageService (a simplified FileRegistry)
+     * 
+     * @return A shared_ptr on a FileLocation if the DataFile is known to the CompoundStorageService or nullptr if it's not.
+     */
+    std::shared_ptr<FileLocation> CompoundStorageService::lookupFileLocation(const std::shared_ptr<DataFile> &file) {
+        
+        WRENCH_DEBUG("lookupFileLocation: For file %s", file->getID().c_str());
+
+        if (this->file_location_mapping.find(file) == this->file_location_mapping.end()) {
+            WRENCH_DEBUG("lookupFileLocation: File %s is not known by this CompoundStorageService", file->getID().c_str());
+            return nullptr;
+        } else {
+            auto mapped_location = this->file_location_mapping[file];
+            WRENCH_DEBUG("lookupFileLocation: File %s is known by this CompoundStorageService and associated to storage service %s", 
+                        mapped_location->getFile()->getID().c_str(), 
+                        mapped_location->getStorageService()->getName().c_str()
+            );
+            return mapped_location;
+        }
+    }
+
+    /** 
+     *  @brief Lookup for a FileLocation (using its internal DataFile) in the internal file mapping of the CompoundStorageService 
+     *         (a simplified FileRegistry) 
+     * 
+     *  @return A shared_ptr on a FileLocation if the DataFile is known to the CompoundStorageService or nullptr if it's not.
+     */
+    std::shared_ptr<FileLocation> CompoundStorageService::lookupFileLocation(const std::shared_ptr<FileLocation> &location) {
+        return this->lookupFileLocation(location->getFile());
+    }
+
+
+    /**
+     *  @brief Lookup for a DataFile in the internal file mapping of the CompoundStorageService, and if it is not found, 
+     *         try to allocate the file on one of the underlying storage services, using the user-provided 'storage_selection'
+     *         callback.
+     * 
+     *  @return A shared_ptr on a FileLocation if the DataFile is known to the CompoundStorageService or could be allocated
+     *          or nullptr if it's not.
+     */
+    std::shared_ptr<FileLocation> CompoundStorageService::lookupOrDesignateStorageService(const std::shared_ptr<DataFile> concrete_file_location) {
+
+        if (this->lookupFileLocation(concrete_file_location)) {
+            WRENCH_DEBUG("lookupOrDesignateStorageService: File %s already known by CSS", concrete_file_location->getID().c_str());
+            return this->file_location_mapping[concrete_file_location];
+        }
+
+        WRENCH_DEBUG("lookupOrDesignateStorageService: File %s NOT already known by CSS", concrete_file_location->getID().c_str());
+        auto designatedLocation = this->storage_selection(concrete_file_location, this->storage_services, this->file_location_mapping);
+
+        if (!designatedLocation) {
+            WRENCH_DEBUG("lookupOrDesignateStorageService: File %s could not be placed on any ss", concrete_file_location->getID().c_str());
+        } else {
+            WRENCH_DEBUG("lookupOrDesignateStorageService: Registering file %s on storage service %s, at path %s", 
+                        designatedLocation->getFile()->getID().c_str(),
+                        designatedLocation->getStorageService()->getName().c_str(),
+                        designatedLocation->getFullAbsolutePath().c_str()    
+            );
+
+            // Supposing (and it better be true) that DataFiles are unique throught a given simulation run, even among various jobs.
+            this->file_location_mapping[designatedLocation->getFile()] = designatedLocation;
+        }
+
+        return designatedLocation;
+    }
+
+    /**
+     *  @brief Lookup for a FileLocation (using its internal DataFile) in the internal file mapping of the CompoundStorageService, 
+     *         and if it is not found, try to allocate the file on one of the underlying storage services, using the user-provided 
+     *         'storage_selection' callback.
+     * 
+     *  @return A shared_ptr on a FileLocation if the DataFile is known to the CompoundStorageService or could be allocated
+     *          or nullptr if it's not.
+     */
+    std::shared_ptr<FileLocation> CompoundStorageService::lookupOrDesignateStorageService(const std::shared_ptr<FileLocation> location) {
+        return this->lookupOrDesignateStorageService(location->getFile());
+    }
+
+    /**
+     * @brief Handle (and intercept) a file delete request
+     *
+     * @param msg: The StorageServiceFileDeleteRequestMessage received by a CompoundStorageService
+     * @return true if this process should keep running
+     */
+    bool CompoundStorageService::processFileDeleteRequest(StorageServiceFileDeleteRequestMessage *msg) {
+
+        auto designated_location = this->lookupFileLocation(msg->location);
+        if (!designated_location) {
+
+            WRENCH_WARN("processFileDeleteRequest: Unable to find file %s", 
+                        msg->location->getFile()->getID().c_str());
+            try {        
+                S4U_Mailbox::dputMessage(
+                    msg->answer_mailbox,
+                    new StorageServiceFileDeleteAnswerMessage(
+                            nullptr,
+                            this->getSharedPtr<CompoundStorageService>(),
+                            false,
+                            std::shared_ptr<FailureCause>(new FileNotFound(msg->location)),
+                            this->getMessagePayloadValue(
+                                    CompoundStorageServiceMessagePayload::FILE_DELETE_ANSWER_MESSAGE_PAYLOAD)));
+            } catch (wrench::ExecutionException &e) {}
+        
+            return true;
+        }
+
+        S4U_Mailbox::putMessage(
+            designated_location->getStorageService()->mailbox,
+            new StorageServiceFileDeleteRequestMessage(
+                msg->answer_mailbox,
+                designated_location,
+                designated_location->getStorageService()->getMessagePayloadValue(
+                    StorageServiceMessagePayload::FILE_DELETE_REQUEST_MESSAGE_PAYLOAD)
+            )
+        );
+
+        return true;
+    }
+    
+    /**
+     * @brief Handle (and intercept) a file lookup request
+     *
+     * @param msg: The StorageServiceFileLookupRequestMessage received by a CompoundStorageService
+     * @return true if this process should keep running
+     */
+    bool CompoundStorageService::processFileLookupRequest(StorageServiceFileLookupRequestMessage* msg) {
+        
+        auto designated_location = this->lookupFileLocation(msg->location);
+        if (!designated_location) {
+            
+            WRENCH_WARN("processFileLookupRequest: Unable to find file %s", msg->location->getFile()->getID().c_str());
+            // Abort because we don't know the file (it should have been written or copied somewhere before the lookup happens)
+            try {
+                S4U_Mailbox::dputMessage(
+                    msg->answer_mailbox,
+                    new StorageServiceFileLookupAnswerMessage(
+                        nullptr, false,
+                        this->getMessagePayloadValue(
+                            CompoundStorageServiceMessagePayload::FILE_LOOKUP_ANSWER_MESSAGE_PAYLOAD)));
+            } catch (wrench::ExecutionException &e) {}
+            
+            return true;
+        }
+
+        // The file is known, we can forward the request to the underlying designated StorageService
+        S4U_Mailbox::putMessage(
+            designated_location->getStorageService()->mailbox,
+            new StorageServiceFileLookupRequestMessage(
+                msg->answer_mailbox,
+                FileLocation::LOCATION(
+                    designated_location->getStorageService(), 
+                    designated_location->getFullAbsolutePath(), 
+                    designated_location->getFile()
+                ),
+                designated_location->getStorageService()->getMessagePayloadValue(
+                    StorageServiceMessagePayload::FILE_LOOKUP_REQUEST_MESSAGE_PAYLOAD))
+        );
+
+        return true;
+
+    }
+
+    /**
+     * @brief Handle (and intercept) a file copy request
+     *
+     * @param msg: The StorageServiceFileCopyRequestMessage received by a CompoundStorageService
+     * @return true if this process should keep running
+     */
+    bool CompoundStorageService::processFileCopyRequest(StorageServiceFileCopyRequestMessage *msg) {
+
+        // If source location references a CSS, it must already be known to the CSS
+        auto final_src = msg->src;
+        if (std::dynamic_pointer_cast<CompoundStorageService>(msg->src->getStorageService())) {
+            final_src = this->lookupFileLocation(msg->src->getFile()); 
+        }
+        // If destination location references a CSS, it must already exist OR we must be able to allocate it
+        auto final_dst = msg->dst;
+        if (std::dynamic_pointer_cast<CompoundStorageService>(msg->dst->getStorageService())) {
+            final_dst = this->lookupOrDesignateStorageService(msg->dst);
+        }
+
+        // Error case - src
+        if (!final_src) {
+           
+            WRENCH_WARN("processFileCopyRequest: Source %s is a CompoundStorageService and file doesn't exist yet.", 
+                        msg->src->getStorageService()->getName().c_str());
+            try {
+                std::string error = "CompoundStorageService can't be the source of a file copy if the file has"
+                                    " not already been written or copied to it.";
+
+                S4U_Mailbox::putMessage(
+                    msg->answer_mailbox,
+                    new StorageServiceFileCopyAnswerMessage(
+                        msg->src,
+                        msg->dst,
+                        nullptr, 
+                        false,
+                        false,
+                        std::shared_ptr<FailureCause>(new NotAllowed(
+                            this->getSharedPtr<CompoundStorageService>(),
+                            error)
+                        ),
+                        this->getMessagePayloadValue(
+                            CompoundStorageServiceMessagePayload::FILE_COPY_ANSWER_MESSAGE_PAYLOAD)
+                    )
+                );
+            } catch (ExecutionException &e) {}
+
+            return true;
+        }
+
+        // Error case - dst
+        if (!final_dst) {
+
+            WRENCH_WARN("processFileCopyRequest: Destination file %s not found or not enough space left",
+                        msg->dst->getFile()->getID().c_str());
+
+            std::shared_ptr<FailureCause> failure_cause;
+            if (!this->isStorageSelectionUserProvided) {
+                std::string err = "CompoundStorageService doesn't know dst file and can't allocate it because no storage_selection callback was provided";
+                failure_cause = std::make_shared<NotAllowed>(
+                    this->getSharedPtr<CompoundStorageService>(),
+                    err
+                );
+            } else {
+                failure_cause = std::make_shared<StorageServiceNotEnoughSpace>(
+                    msg->dst->getFile(), 
+                    this->getSharedPtr<CompoundStorageService>()
+                );
+            }
+
+            try {
+                S4U_Mailbox::putMessage(
+                    msg->answer_mailbox,
+                    new StorageServiceFileCopyAnswerMessage(
+                        msg->src,
+                        msg->dst,
+                        nullptr, 
+                        false,
+                        false,
+                        failure_cause,
+                        this->getMessagePayloadValue(
+                            CompoundStorageServiceMessagePayload::FILE_COPY_ANSWER_MESSAGE_PAYLOAD))
+                );
+            } catch (ExecutionException &e) {}
+
+            return true;
+        }
+        
+        // Depending on whether we updated source or destination, we now need to find 
+        // to which to forward the message
+        bool src_is_bufferized = final_src->getStorageService()->isBufferized();
+        bool dst_is_bufferized = final_dst->getStorageService()->isBufferized();
+        
+        simgrid::s4u::Mailbox *mailbox_to_contact;
+        if (!dst_is_bufferized) {
+            mailbox_to_contact = final_dst->getStorageService()->mailbox;
+        } else if (!src_is_bufferized) {
+            mailbox_to_contact = final_src->getStorageService()->mailbox;
+        } else {
+            mailbox_to_contact = final_dst->getStorageService()->mailbox;
+        }
+
+        S4U_Mailbox::putMessage(
+            mailbox_to_contact,
+            new StorageServiceFileCopyRequestMessage(
+                    msg->answer_mailbox,
+                    final_src,
+                    final_dst,
+                    nullptr,
+                    final_dst->getStorageService()->getMessagePayloadValue(
+                            StorageServiceMessagePayload::FILE_COPY_REQUEST_MESSAGE_PAYLOAD)
+            )
+        );
+
+        return true;
+    }
+
+    /**
+     * @brief Handle (and intercept) a file write request. 
+     *        Note: Currently it's not reachable, because we also override a writeFile,
+     *        but intercepting the write message would probably be better.
+     *
+     * @param msg: The StorageServiceFileWriteRequestMessage received by a CompoundStorageService
+     * @return true if this process should keep running
+     */
+    bool CompoundStorageService::processFileWriteRequest(StorageServiceFileWriteRequestMessage* msg) {
+
+        auto designated_location = this->lookupOrDesignateStorageService(msg->location);
+        if (!designated_location) {
+
+            WRENCH_WARN("processFileWriteRequest: Destination file %s not found or not enough space left",
+                        msg->location->getFile()->getID().c_str());
+            try {
+                S4U_Mailbox::dputMessage(
+                    msg->answer_mailbox,
+                    new StorageServiceFileWriteAnswerMessage(
+                            msg->location,
+                            false,
+                            std::shared_ptr<FailureCause>(new FileNotFound(msg->location)),
+                            nullptr,
+                            this->getMessagePayloadValue(
+                                    CompoundStorageServiceMessagePayload::FILE_WRITE_ANSWER_MESSAGE_PAYLOAD)));
+            } catch (wrench::ExecutionException &e) {}
+            
+            return true;
+        }
+
+        // The file is known or added to the local mapping, we can forward the request to the underlying designated StorageService
+        S4U_Mailbox::putMessage(
+            designated_location->getStorageService()->mailbox,
+            new StorageServiceFileWriteRequestMessage(
+                msg->answer_mailbox,
+                msg->requesting_host,
+                designated_location,
+                0,
+                this->getMessagePayloadValue(
+                    StorageServiceMessagePayload::FILE_WRITE_REQUEST_MESSAGE_PAYLOAD)
+            )
+        );
+
+        return true;
+    }
+
+    /**
+     * @brief Handle (and intercept) a file read request. 
+     *
+     * @param msg: The StorageServiceFileReadRequestMessage received by a CompoundStorageService
+     * @return true if this process should keep running
+     */
+    bool CompoundStorageService::processFileReadRequest(StorageServiceFileReadRequestMessage* msg) {        
+        
+        auto designated_location = this->lookupFileLocation(msg->location);
+        if (!designated_location) {
+
+            WRENCH_WARN("processFileReadRequest: file %s not found", msg->location->getFile()->getID().c_str());
+            try {
+                S4U_Mailbox::dputMessage(
+                    msg->answer_mailbox,
+                    new StorageServiceFileReadAnswerMessage(
+                        msg->location,
+                        false,
+                        std::shared_ptr<FailureCause>(new FileNotFound(msg->location)),
+                        nullptr,
+                        0,
+                        this->getMessagePayloadValue(
+                            CompoundStorageServiceMessagePayload::FILE_READ_ANSWER_MESSAGE_PAYLOAD))
+                );
+            } catch (wrench::ExecutionException &e) {}
+
+            return true;
+
+        }
+
+        WRENCH_DEBUG("processFileReadRequest: Going to read file %s on storage service %s, at path %s", 
+                        designated_location->getFile()->getID().c_str(),
+                        designated_location->getStorageService()->getName().c_str(),
+                        designated_location->getFullAbsolutePath().c_str()    
+        );        
+
+        S4U_Mailbox::putMessage(
+            designated_location->getStorageService()->mailbox,
+            new StorageServiceFileReadRequestMessage(
+                msg->answer_mailbox,
+                msg->requesting_host,
+                designated_location,
+                msg->num_bytes_to_read,
+                designated_location->getStorageService()->getMessagePayloadValue(
+                        StorageServiceMessagePayload::FILE_READ_REQUEST_MESSAGE_PAYLOAD)
+            )
+        );
+
+        return true;
+    }
+
+
+    /**
+     * @brief Get the load (number of concurrent reads) on the storage service
+     *        Not implemented yet for CompoundStorageService (is it needed?)
+     * @return the load on the service (currently throws)
+     */
+    double CompoundStorageService::getLoad() {
+        WRENCH_WARN("CompoundStorageService::getLoad Not implemented");
+        throw std::logic_error("CompoundStorageService::getLoad(): Not implemented. "
+                                "Call getLoad() on an underlying storage service instead");
+    }
+
+    /**
+     * @brief Get the total space across all internal services known by the CompoundStorageService
+     * 
+     * @return A map of service name and total capacity of all disks for each service.
+     */
+    std::map<std::string, double> CompoundStorageService::getTotalSpace() {
+
+        WRENCH_INFO("CompoundStorageService::getTotalSpace");
+        std::map<std::string, double> to_return;
+        for (const auto & service : this->storage_services) {
+            auto service_name = service->getName();
+            auto service_capacity = service->getTotalSpace();
+            to_return[service_name] = std::accumulate(service_capacity.begin(), service_capacity.end(), 0, 
+                                                        [](const std::size_t previous, const auto& element){ return previous + element.second;});
+        }
+        return to_return;
+    }
+
+    /**
+     * @brief Synchronously asks the storage services inside the compound storage service 
+     *        for their free space at all of their mount points
+     * 
+     * @return The free space in bytes of each mount point, as a map
+     *
+     * @throw ExecutionException
+     *
+     * @throw std::runtime_error
+     *
+     */
+    std::map<std::string, double> CompoundStorageService::getFreeSpace() {
+
+        WRENCH_DEBUG("CompoundStorageService::getFreeSpace Forwarding request to internal services");
+
+        std::map<std::string, double> to_return = {}; 
+        std::map<std::string, simgrid::s4u::Mailbox*> mailboxes = {};
+
+        for (const auto & service : this->storage_services) {
+            
+            auto free_space = service->getFreeSpace();
+
+            to_return[service->getName()] = std::accumulate(free_space.begin(), free_space.end(), 0, 
+                                                          [](const std::size_t previous, const auto& element){return previous + element.second;}
+            );
+
+        }
+
+        return to_return;
+    }
+
+    /** 
+     *  @brief setScratch can't be used on a CompoundStorageService because it doesn't have any actual storage resources.
+     *  
+     *  @throw std::logic_error
+     */
+    void CompoundStorageService::setScratch() {
+        WRENCH_WARN("CompoundStorageService::setScratch Forbidden because CompoundStorageService doesn't manage any storage resources itself");
+        throw std::logic_error("CompoundStorageService can't be setup as a scratch space, it is only an abstraction layer.");
+    }
+
+    /**
+     * @brief Return the set of all services accessible through this CompoundStorageService
+     * 
+     * @return The set of known StorageServices.
+    */
+    std::set<std::shared_ptr<StorageService>>& CompoundStorageService::getAllServices() {
+        WRENCH_DEBUG("CompoundStorageService::getAllServices");
+        return this->storage_services;
+    }
+
+    /**
+     * @brief Get a file's last write date at a location (in zero simulated time)
+     *
+     * @param location: the file last write date
+     * 
+     * @throw std::invalid_argument if file is not know to the CompoundStorageService and 
+     *        std::logic_error if file is known but allocated on a StorageService which doesn't implement this method.
+     *
+     * @return the file's last write date, or -1 if the file is not found
+     *
+     */
+    double CompoundStorageService::getFileLastWriteDate(const std::shared_ptr<FileLocation> &location) {
+
+        if (!this->lookupFile(location)) {
+            throw std::invalid_argument("CompoundStorageService::getFileLastWriteDate(): File not known to the CompoundStorageService. Unable to forward to underlying StorageService");
+        }
+
+        auto designated_storage_service = std::dynamic_pointer_cast<SimpleStorageService>(*(this->storage_services.find(location->getStorageService())));
+        if (designated_storage_service) {
+            return designated_storage_service->getFileLastWriteDate(this->file_location_mapping[location->getFile()]);
+        } else {
+            throw std::logic_error("CompoundStorageService::getFileLastWriteDate(): File known, but allocated on StorageService that doesn't implement getFileLastWriteDate()");
+        }
+
+    }
+
+    bool CompoundStorageService::hasFile(const std::shared_ptr<DataFile> &file, const std::string &path) {
+        auto file_location = this->lookupFileLocation(file);
+        if (!file_location) {
+            WRENCH_DEBUG("hasFile: File %s not found", file->getID().c_str());
+            return false;
+        }
+        if (file_location->getAbsolutePathAtMountPoint() != path) {
+            WRENCH_DEBUG("hasFile: File %s found, but path %s doesn't match internal path %s", 
+                file->getID().c_str(), path.c_str(), file_location->getAbsolutePathAtMountPoint().c_str());
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+    * @brief Generate a unique number
+    *
+    * @return a unique number
+    */
+    unsigned long CompoundStorageService::getNewUniqueNumber() {
+        static unsigned long sequence_number = 0;
+        return (sequence_number++);
+    }
+
+    /**
+     * @brief Process a stop daemon request
+     * 
+     * @param ack_mailbox: the mailbox to which the ack should be sent
+     * 
+     * @throw wrench::ExecutionException if communication fails.
+     * 
+     * @return false if the daemon should terminate
+     */
+    bool CompoundStorageService::processStopDaemonRequest(simgrid::s4u::Mailbox *ack_mailbox) {
+        try {
+            S4U_Mailbox::putMessage(ack_mailbox,
+                                    new ServiceDaemonStoppedMessage(this->getMessagePayloadValue(
+                                            CompoundStorageServiceMessagePayload::DAEMON_STOPPED_MESSAGE_PAYLOAD)));
+        } catch (ExecutionException &e) {
+            return false;
+        }
+        return false;
+    }
+
+};// namespace wrench

--- a/src/wrench/services/storage/compound/CompoundStorageServiceMessagePayload.cpp
+++ b/src/wrench/services/storage/compound/CompoundStorageServiceMessagePayload.cpp
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2017. The WRENCH Team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <wrench/services/storage/compound/CompoundStorageServiceMessagePayload.h>
+
+namespace wrench {
+
+
+};

--- a/src/wrench/services/storage/compound/CompoundStorageServiceProperty.cpp
+++ b/src/wrench/services/storage/compound/CompoundStorageServiceProperty.cpp
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2017. The WRENCH Team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <wrench/services/storage/compound/CompoundStorageServiceProperty.h>
+
+namespace wrench {
+
+    
+    SET_PROPERTY_NAME(CompoundStorageServiceProperty, STORAGE_SELECTION_METHOD);
+
+};

--- a/src/wrench/services/storage/storage_helper_classes/FileLocation.cpp
+++ b/src/wrench/services/storage/storage_helper_classes/FileLocation.cpp
@@ -11,6 +11,7 @@
 #include <wrench/logging/TerminalOutput.h>
 #include <wrench/services/storage/StorageService.h>
 #include <wrench/services/storage/storage_helpers/FileLocation.h>
+#include <wrench/services/storage/compound/CompoundStorageService.h>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <iostream>
@@ -213,6 +214,16 @@ namespace wrench {
     }
 
     /**
+     * @brief Update storage service
+     * @return The updated storage service
+     */
+    std::shared_ptr<StorageService> FileLocation::setStorageService(std::shared_ptr<StorageService> storage_service) {
+        this->storage_service = std::move(storage_service);
+        return this->storage_service;
+    }
+
+
+    /**
      * @brief Get the location's file
      * @return a file
      */
@@ -241,6 +252,15 @@ namespace wrench {
         }
         return this->mount_point;
     }
+
+    std::string FileLocation::setMountPoint(std::string mount_point) {
+        if (this->is_scratch) {
+            throw std::invalid_argument("FileLocation::getMountPoint(): No mount point for a SCRATCH location");
+        }
+        this->mount_point = std::move(mount_point);
+        return this->mount_point;
+    }
+
 
     /**
      * @brief Get the location's path at mount point

--- a/src/wrench/simulation/Simulation.cpp
+++ b/src/wrench/simulation/Simulation.cpp
@@ -16,6 +16,7 @@
 #include <wrench/logging/TerminalOutput.h>
 #include <wrench/services/file_registry/FileRegistryService.h>
 #include <wrench/services/storage/StorageService.h>
+#include <wrench/services/storage/compound/CompoundStorageService.h>
 #include <wrench/simulation/Simulation.h>
 #include "simgrid/plugins/energy.h"
 #include <wrench/simgrid_S4U_util/S4U_Mailbox.h>
@@ -758,6 +759,10 @@ namespace wrench {
     void Simulation::stageFile(const std::shared_ptr<FileLocation> &location) {
         if (location == nullptr) {
             throw std::invalid_argument("Simulation::stageFile(): Invalid nullptr arguments");
+        }
+
+        if (std::dynamic_pointer_cast<CompoundStorageService>(location->getStorageService())) {
+            throw std::invalid_argument("Simulation::stageFile(): Can't stage on CompoundStorageService (it is only an abstraction layer)");
         }
 
         if (this->is_running) {

--- a/test/services/storage_services/CompoundStorageService/CompoundStorageServiceFunctionalTest.cpp
+++ b/test/services/storage_services/CompoundStorageService/CompoundStorageServiceFunctionalTest.cpp
@@ -1,0 +1,710 @@
+/**
+ * Copyright (c) 2017. The WRENCH Team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+
+#include <gtest/gtest.h>
+#include <vector>
+
+#include <xbt/log.h>
+#include <wrench-dev.h>
+#include "../../../include/TestWithFork.h"
+#include "../../../include/UniqueTmpPathPrefix.h"
+
+WRENCH_LOG_CATEGORY(Compound_storage_service_functional_test, "Log category for CompoundStorageServiceFunctionalTest");
+
+
+class CompoundStorageServiceFunctionalTest : public ::testing::Test {
+
+public:
+
+    std::shared_ptr<wrench::Workflow> workflow;
+
+    std::shared_ptr<wrench::DataFile> file_1;
+    std::shared_ptr<wrench::DataFile> file_10;
+    std::shared_ptr<wrench::DataFile> file_100;
+    std::shared_ptr<wrench::DataFile> file_500;
+    std::shared_ptr<wrench::DataFile> file_1000;
+
+    std::shared_ptr<wrench::SimpleStorageService> simple_storage_service_100 = nullptr;
+    std::shared_ptr<wrench::SimpleStorageService> simple_storage_service_510 = nullptr;
+    std::shared_ptr<wrench::SimpleStorageService> simple_storage_service_1000 = nullptr;
+    std::shared_ptr<wrench::CompoundStorageService> compound_storage_service = nullptr;
+
+    std::shared_ptr<wrench::ComputeService> compute_service = nullptr;
+
+    void do_BasicFunctionality_test();
+    void do_BasicInterceptFunctionality_test();
+    void do_BasicError_test();
+
+protected:
+
+    ~CompoundStorageServiceFunctionalTest() {
+        workflow->clear();
+    }
+
+    CompoundStorageServiceFunctionalTest() {
+
+        workflow = wrench::Workflow::createWorkflow();
+
+        // Create the files
+        file_1 = workflow->addFile("file_1", 1.0);
+        file_10 = workflow->addFile("file_10", 10.0);
+        file_100 = workflow->addFile("file_100", 100.0);
+        file_500 = workflow->addFile("file_500", 500.0);
+        file_1000 = workflow->addFile("file_1000", 1000.0);
+
+        // Create a three-hosts platform file (2 for simple storage, one for Compound Storage)
+        std::string xml = "<?xml version='1.0'?>"
+                          "<!DOCTYPE platform SYSTEM \"https://simgrid.org/simgrid.dtd\">"
+                          "<platform version=\"4.1\"> "
+                          "   <zone id=\"AS0\" routing=\"Full\"> "
+                          "       <host id=\"ComputeHost\" speed=\"1f\">"
+                          "       </host>"
+                          "       <host id=\"SimpleStorageHost0\" speed=\"1f\">"
+                          "          <disk id=\"large_disk\" read_bw=\"100MBps\" write_bw=\"100MBps\">"
+                          "             <prop id=\"size\" value=\"100B\"/>"
+                          "             <prop id=\"mount\" value=\"/disk100/\"/>"
+                          "          </disk>"
+                          "          <disk id=\"other_large_disk\" read_bw=\"100MBps\" write_bw=\"100MBps\">"
+                          "             <prop id=\"size\" value=\"510B\"/>"
+                          "             <prop id=\"mount\" value=\"/disk510/\"/>"
+                          "          </disk>"
+                          "          <disk id=\"other_other_large_disk\" read_bw=\"100MBps\" write_bw=\"100MBps\">"
+                          "             <prop id=\"size\" value=\"1000B\"/>"
+                          "             <prop id=\"mount\" value=\"/disk1000/\"/>"
+                          "          </disk>"
+                          "       </host>"
+                          "       <host id=\"SimpleStorageHost1\" speed=\"1f\">"
+                          "          <disk id=\"large_disk\" read_bw=\"100MBps\" write_bw=\"100MBps\">"
+                          "             <prop id=\"size\" value=\"100B\"/>"
+                          "             <prop id=\"mount\" value=\"/disk100/\"/>"
+                          "          </disk>"
+                          "          <disk id=\"other_large_disk\" read_bw=\"100MBps\" write_bw=\"100MBps\">"
+                          "             <prop id=\"size\" value=\"510B\"/>"
+                          "             <prop id=\"mount\" value=\"/disk510/\"/>"
+                          "          </disk>"
+                          "          <disk id=\"other_other_large_disk\" read_bw=\"100MBps\" write_bw=\"100MBps\">"
+                          "             <prop id=\"size\" value=\"1000B\"/>"
+                          "             <prop id=\"mount\" value=\"/disk1000/\"/>"
+                          "          </disk>"
+                          "       </host>"
+                          "       <host id=\"CompoundStorageHost\" speed=\"1f\">"
+                          "       </host>"
+                          "       <link id=\"Link1\" bandwidth=\"50MBps\" latency=\"150us\"/> "
+                          "       <route src=\"CompoundStorageHost\" dst=\"SimpleStorageHost0\"><link_ctn id=\"Link1\"/></route> "
+                          "       <route src=\"CompoundStorageHost\" dst=\"SimpleStorageHost1\"><link_ctn id=\"Link1\"/></route> "
+                          "       <route src=\"CompoundStorageHost\" dst=\"ComputeHost\"><link_ctn id=\"Link1\"/></route> "
+                          "       <route src=\"SimpleStorageHost0\" dst=\"ComputeHost\"><link_ctn id=\"Link1\"/></route> "
+                          "       <route src=\"SimpleStorageHost1\" dst=\"ComputeHost\"><link_ctn id=\"Link1\"/></route> "
+                          "       <route src=\"SimpleStorageHost0\" dst=\"SimpleStorageHost1\"><link_ctn id=\"Link1\"/></route> "
+                          "   </zone> "
+                          "</platform>";
+        FILE *platform_file = fopen(platform_file_path.c_str(), "w");
+        fprintf(platform_file, "%s", xml.c_str());
+        fclose(platform_file);
+    }
+
+    std::string platform_file_path = UNIQUE_TMP_PATH_PREFIX + "platform.xml";
+};
+
+
+/**********************************************************************/
+/**  BASIC FUNCTIONALITY SIMULATION TEST                             **/
+/**********************************************************************/
+
+class CompoundStorageServiceBasicFunctionalityTestCtrl : public wrench::ExecutionController {
+
+public:
+    CompoundStorageServiceBasicFunctionalityTestCtrl(CompoundStorageServiceFunctionalTest *test,
+                                                  std::string hostname) : wrench::ExecutionController(hostname, "test"), test(test) {
+    }
+
+private:
+    CompoundStorageServiceFunctionalTest *test;
+
+    int main() {
+
+        wrench::S4U_Simulation::computeZeroFlop();
+
+        // Retrieve internal SimpleStorageServices
+        auto simple_storage_services = test->compound_storage_service->getAllServices();
+        std::set<std::shared_ptr<wrench::StorageService>> expected_services{test->simple_storage_service_100, test->simple_storage_service_510};
+        if (simple_storage_services != expected_services) {
+            throw std::runtime_error("The list of returned simple storage services is incorrect");
+        }
+
+        
+        // Verify synchronous request for current free space (currently same as capacity, as no file has been placed on internal services)
+        auto expected_capacity = std::map<std::string, double>(
+            {{test->simple_storage_service_100->getName(), 100.0}, {test->simple_storage_service_510->getName(), 610.0}}
+        );
+        auto free_space = test->compound_storage_service->getFreeSpace();
+        if (free_space != expected_capacity) {
+            throw std::runtime_error("'Free Space' available to CompoundStorageService is incorrect");
+        }
+    
+        // Verify that total space is correct
+        auto capacity = test->compound_storage_service->getTotalSpace();
+        if (capacity != expected_capacity) {
+            throw std::runtime_error("'Total Space' available to CompoundStorageService is incorrect");
+        }
+
+        // Verify that compound storage service unique mount point is DEV_NULL
+        auto mount_point = test->compound_storage_service->getMountPoint();
+        if (mount_point != wrench::LogicalFileSystem::DEV_NULL + "/") {
+            throw std::runtime_error("CompoundStorageService should have only one 'LogicalFileSystem::DEV_NULL' filesystem");
+        }
+
+        // We don't support getLoad or getFileLastWriteDate on CompoundStorageService yet (and won't ?)
+        try {
+            test->compound_storage_service->getLoad();
+            throw std::runtime_error("CompoundStorageService doesn't have a getLoad() implemented");
+        } catch (std::logic_error &e) {}
+
+        {
+            auto file_1_loc = wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1);
+            try {
+                test->compound_storage_service->getFileLastWriteDate(file_1_loc);
+                throw std::runtime_error("We shouldn't be able to get a FileLastWriteDate on a file that wasn't written to the CSS first");
+            } catch (std::invalid_argument &e) {}
+        }
+
+        
+        // CompoundStorageServer should never be a scratch space (at init or set as later)
+        if (test->compound_storage_service->isScratch() == true) {
+            throw std::runtime_error("CompoundStorageService should never have isScratch == true");
+        }
+
+        try {
+            test->compound_storage_service->setScratch();
+            throw std::runtime_error("CompoundStorageService can't be setup as a scratch space");
+        } catch (std::logic_error &e) {}
+
+        if (test->compound_storage_service->isBufferized()) {
+            throw std::runtime_error("CompoundStorageService shouldn't be bufferized");
+        }
+        
+        // ## Test multiple messages that should answer with a failure cause, and in turn generate an ExecutionException
+        // on caller's side
+
+        // File copy, CSS as src, file not known:
+        {
+            auto file_1_loc_ss = wrench::FileLocation::LOCATION(test->simple_storage_service_100, test->file_1);
+            this->simulation->createFile(file_1_loc_ss);
+            auto file_1_loc_css = wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1);
+        
+            try {
+                wrench::StorageService::copyFile(file_1_loc_css, file_1_loc_ss);
+                throw std::runtime_error("File doesn't exist on CSS, copy with CSS as src should be impossible");
+            } catch (wrench::ExecutionException &e) {
+                if (!std::dynamic_pointer_cast<wrench::NotAllowed>(e.getCause())) {
+                    throw std::runtime_error("Exception cause should have been 'NotAllowed'");
+                }
+            }
+            test->simple_storage_service_100->deleteFile(file_1_loc_ss);
+        }
+
+        // File copy, CSS as dst, file can't be allocated (no callback provided) - src file exists:
+        {
+            auto file_1_loc_ss = wrench::FileLocation::LOCATION(test->simple_storage_service_100, test->file_1);
+            this->simulation->createFile(file_1_loc_ss);
+            auto file_1_loc_css = wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1);
+        
+            try {
+                wrench::StorageService::copyFile(file_1_loc_ss, file_1_loc_css);
+                throw std::runtime_error("File doesn't exist and can't be allocated on CSS, copy with CSS as dst should be impossible");
+            } catch (wrench::ExecutionException &e) {
+                if (!std::dynamic_pointer_cast<wrench::NotAllowed>(e.getCause())) {
+                    throw std::runtime_error("Exception cause should have been 'NotAllowed' because no storage_selection callback was provided");
+                }
+            }
+            test->simple_storage_service_100->deleteFile(file_1_loc_ss);
+        }
+
+        auto file_1_loc_ss = wrench::FileLocation::LOCATION(test->simple_storage_service_100, test->file_1);
+        auto file_1_loc_css = wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1);
+    
+        try {
+            wrench::StorageService::deleteFile(file_1_loc_css);
+            throw std::runtime_error("Should not be able to delete file from a CompoundStorageService if it has not first been written / copied to it");
+        } catch (wrench::ExecutionException &) {}
+
+        try {
+            wrench::StorageService::readFile(file_1_loc_css);
+            throw std::runtime_error("Should not be able to read file from a CompoundStorageService if it has not first been written / copied to it");
+        } catch (wrench::ExecutionException &) {}
+        
+        
+        try {
+            wrench::StorageService::writeFile(file_1_loc_css);
+            throw std::runtime_error("Should not be able to write file on a CompoundStorageService because no selection callback was provided");
+        } catch (wrench::ExecutionException &e) {}
+        
+
+        // This one simply answers that the file was not found
+        if (wrench::StorageService::lookupFile(file_1_loc_css))
+            throw std::runtime_error("Should not be able to lookup file from a CompoundStorageService if it has not been written/copied to it first");
+       
+
+        return 0;
+    }
+};
+
+TEST_F(CompoundStorageServiceFunctionalTest, BasicFunctionality) {
+    DO_TEST_WITH_FORK(do_BasicFunctionality_test);
+}
+
+void CompoundStorageServiceFunctionalTest::do_BasicFunctionality_test() {
+
+    // Create and initialize a simulation
+    auto simulation = wrench::Simulation::createSimulation();
+
+    xbt_log_control_set("wrench_core_storage_service.thres:debug");
+    xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+    xbt_log_control_set("wrench_core_compound_storage_system.thresh:debug");
+    xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+
+    int argc = 1;
+    char **argv = (char **) calloc(argc, sizeof(char *));
+    argv[0] = strdup("unit_test");
+    // argv[1] = strdup("--wrench-full-log");
+
+    // Setting up simulation and platform
+    ASSERT_NO_THROW(simulation->init(&argc, argv));
+    ASSERT_NO_THROW(simulation->instantiatePlatform(platform_file_path));
+
+    // Syntaxic sugar
+    auto compute = "ComputeHost";
+    auto simple_storage0 = "SimpleStorageHost0";
+    auto simple_storage1 = "SimpleStorageHost1";
+    auto compound_storage = "CompoundStorageHost";
+
+    // Create a Compute Service
+    ASSERT_NO_THROW(
+        compute_service = simulation->add(
+            new wrench::BareMetalComputeService(compute,
+                                                {std::make_pair(compute, std::make_tuple(wrench::ComputeService::ALL_CORES,
+                                                                                         wrench::ComputeService::ALL_RAM))},
+                                                {})));
+
+    // Create some simple storage services
+    // Unbufferized
+    ASSERT_NO_THROW(simple_storage_service_100 = simulation->add(
+                        wrench::SimpleStorageService::createSimpleStorageService(simple_storage0, {"/disk100"},
+                            {}, {})));
+    // Bufferized
+    ASSERT_NO_THROW(simple_storage_service_510 = simulation->add(
+                        wrench::SimpleStorageService::createSimpleStorageService(simple_storage1, {"/disk100", "/disk510"},
+                            {{wrench::SimpleStorageServiceProperty::BUFFER_SIZE, "1000000"}}, {})));
+
+    // Fail to create a Compound Storage Service (no storage services provided)
+    ASSERT_THROW(compound_storage_service = simulation->add(
+        new wrench::CompoundStorageService(compound_storage, {})),
+        std::invalid_argument);
+
+    // Fail to create a Compound Storage Service (one of the storage service is just a nullptr)
+    ASSERT_THROW(compound_storage_service = simulation->add(
+        new wrench::CompoundStorageService(compound_storage, {simple_storage_service_1000, simple_storage_service_100})),
+        std::invalid_argument);
+
+    // Create a valid Compound Storage Service, without user provided callback (no intercept capabilities)
+    ASSERT_NO_THROW(compound_storage_service = simulation->add(
+                        new wrench::CompoundStorageService(compound_storage, {simple_storage_service_100, simple_storage_service_510})));
+
+    // Create a Controler
+    std::shared_ptr<wrench::ExecutionController> wms = nullptr;
+    ASSERT_NO_THROW(wms = simulation->add(
+                    new CompoundStorageServiceBasicFunctionalityTestCtrl(this, compound_storage)));
+
+    // A bogus staging (can't use CompoundStorageService for staging)
+    ASSERT_THROW(simulation->stageFile(file_10, compound_storage_service), std::invalid_argument);
+
+    // Tun the simulation
+    ASSERT_NO_THROW(simulation->launch());
+
+    for (int i = 0; i < argc; i++)
+        free(argv[i]);
+    free(argv);
+}
+
+
+/**********************************************************************/
+/**  BASIC INTERCEPT FUNCTIONALITY SIMULATION TEST                   **/
+/**********************************************************************/
+
+class CompoundStorageServiceInterceptFunctionalityTestCtrl : public wrench::ExecutionController {
+
+public:
+    CompoundStorageServiceInterceptFunctionalityTestCtrl(CompoundStorageServiceFunctionalTest *test,
+                                                  std::string hostname) : wrench::ExecutionController(hostname, "test"), test(test) {
+    }
+
+private:
+    CompoundStorageServiceFunctionalTest *test;
+
+    int main() {
+
+        std::vector<std::shared_ptr<wrench::Action>> actions;
+
+        // Create a job, and test that messages are correctly forwarded from the css to the underlying storage services
+        auto job_manager = this->createJobManager();
+        auto job1 = job_manager->createCompoundJob("job1");
+
+        // Copy from buffered simple storage to CSS (which uses a non-buffered simplestorage service)
+        simulation->createFile(wrench::FileLocation::LOCATION(test->simple_storage_service_1000, "/disk1000/", test->file_500));
+        auto fileCopyActionSS_CSS = job1->addFileCopyAction(
+            "fileCopySrcBufDstCSSNBuff", 
+            wrench::FileLocation::LOCATION(test->simple_storage_service_1000, "/disk1000/", test->file_500),
+            wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500)
+        );
+        actions.push_back(fileCopyActionSS_CSS);
+
+        // Copy back from CSS (using non-buff SS) to some other place in a bufferized SimpleStorageService
+        auto fileCopyActionCSS_SS = job1->addFileCopyAction(
+            "fileCopySrcCSSNBuffDstBufSS", 
+            wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500),
+            wrench::FileLocation::LOCATION(test->simple_storage_service_1000, "/disk1000/copy_from_css/", test->file_500)
+        );
+        job1->addActionDependency(fileCopyActionSS_CSS, fileCopyActionCSS_SS);
+        actions.push_back(fileCopyActionCSS_SS);
+        
+        // Reading from CSS (previously copied file)
+        auto fileReadAction = job1->addFileReadAction("fileRead1", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500));
+        job1->addActionDependency(fileCopyActionCSS_SS, fileReadAction);
+        actions.push_back(fileReadAction);
+
+        // Write another file to the CSS
+        auto fileWriteAction = job1->addFileWriteAction("fileWrite1", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_100));
+        job1->addActionDependency(fileReadAction, fileWriteAction);
+        actions.push_back(fileWriteAction);
+
+        // Read the file directly from underlying storage service (in this case we know the file will be on simple_storage_service_510, disk 100)
+        auto readWrittenFile = job1->addFileReadAction("directReadFile", wrench::FileLocation::LOCATION(test->simple_storage_service_510, "/disk100/", test->file_100));
+        job1->addActionDependency(fileWriteAction, readWrittenFile);
+        actions.push_back(readWrittenFile);
+
+        // Read it as well through the CSS
+        auto readWrittenFile2 = job1->addFileReadAction("directReadFile2", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_100));
+        job1->addActionDependency(fileWriteAction, readWrittenFile2);
+        actions.push_back(readWrittenFile2);
+
+        // Delete file from CSS
+        auto fileDeleteAction = job1->addFileDeleteAction("fileDelete", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_100));
+        job1->addActionDependency(readWrittenFile, fileDeleteAction);
+        job1->addActionDependency(readWrittenFile2, fileDeleteAction);
+        actions.push_back(fileDeleteAction);
+
+        job_manager->submitJob(job1, test->compute_service, {});
+    
+        std::shared_ptr<wrench::ExecutionEvent> event = this->waitForNextEvent();
+        if (not std::dynamic_pointer_cast<wrench::CompoundJobCompletedEvent>(event)) {
+            throw std::runtime_error("Unexpected workflow execution event: " + event->toString());
+        }
+
+        if (job1->getState() != wrench::CompoundJob::State::COMPLETED) {
+            throw std::runtime_error("Unexpected job state: " + job1->getStateAsString());
+        }        
+        
+        for (auto const &a : actions) {
+            if (a->getState() != wrench::Action::State::COMPLETED) {
+                throw std::runtime_error("One of the actions did not complete");
+            }
+        }
+
+        // lookup a deleted file
+        if (wrench::StorageService::lookupFile(wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_100))) {
+            throw runtime_error("A file supposed to be deleted (on CSS) was not.");
+        }
+        
+        // Check that file copy worked
+        auto file_500_designated_loc = test->compound_storage_service->lookupFileLocation(test->file_500);
+        if (!file_500_designated_loc) {
+            throw std::runtime_error("Should have been able to lookup file_500 through CSS");
+        } else if (file_500_designated_loc->getFullAbsolutePath() != "/disk510/") {
+            throw std::runtime_error("file_500 copy through CSS is not where it should be");
+        }
+
+        return 0;
+    }
+};
+
+TEST_F(CompoundStorageServiceFunctionalTest, BasicInterceptFunctionality) {
+    DO_TEST_WITH_FORK(do_BasicInterceptFunctionality_test);
+}
+
+/* For testing purpose, dummy StorageSelectionStrategyCallback */
+std::shared_ptr<wrench::FileLocation> defaultStorageServiceSelection(
+    const std::shared_ptr<wrench::DataFile>& file, 
+    const std::set<std::shared_ptr<wrench::StorageService>>& resources,
+    const std::map<std::shared_ptr<wrench::DataFile>, std::shared_ptr<wrench::FileLocation>>& mapping) {
+
+    auto capacity_req = file->getSize();
+    
+    std::shared_ptr<wrench::FileLocation> designated_location = nullptr;
+
+    for(const auto& storage_service : resources) {
+
+        auto free_space = storage_service->getFreeSpace();
+        for (const auto& free_space_entry : free_space) {
+            if (free_space_entry.second >= capacity_req) {
+                designated_location = wrench::FileLocation::LOCATION(storage_service, free_space_entry.first, file);
+                break;
+            }
+        }
+    }
+
+    return designated_location;
+}
+
+void CompoundStorageServiceFunctionalTest::do_BasicInterceptFunctionality_test() {
+
+    // Create and initialize a simulation
+    auto simulation = wrench::Simulation::createSimulation();
+    // xbt_log_control_set("ker_engine.thres:debug");
+    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+    // xbt_log_control_set("wrench_core_compound_storage_system.thresh:debug");
+    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+    // xbt_log_control_set("wrench_core_storage_service.thres:info");
+
+    int argc = 1;
+    char **argv = (char **) calloc(argc, sizeof(char *));
+    argv[0] = strdup("unit_test");
+    //    argv[1] = strdup("--wrench-full-log");
+
+    ASSERT_NO_THROW(simulation->init(&argc, argv));
+
+    // Setting up the platform
+    ASSERT_NO_THROW(simulation->instantiatePlatform(platform_file_path));
+
+    // Get a hostname
+    auto compute = "ComputeHost";
+    auto simple_storage0 = "SimpleStorageHost0";
+    auto simple_storage1 = "SimpleStorageHost1";
+    auto compound_storage = "CompoundStorageHost";
+
+    // Create a Compute Service
+    ASSERT_NO_THROW(
+        compute_service = simulation->add(
+            new wrench::BareMetalComputeService(compute,
+                                                {std::make_pair(compute, std::make_tuple(wrench::ComputeService::ALL_CORES,
+                                                                                         wrench::ComputeService::ALL_RAM))},
+                                                {})));
+
+    // Create some simple storage services
+    // Bufferized
+    ASSERT_NO_THROW(simple_storage_service_1000 = simulation->add(
+                        wrench::SimpleStorageService::createSimpleStorageService(simple_storage0, {"/disk1000"},
+                        {{wrench::SimpleStorageServiceProperty::BUFFER_SIZE, "1000000"}}, {})));
+
+    // Non-bufferized
+    ASSERT_NO_THROW(simple_storage_service_100 = simulation->add(
+                        wrench::SimpleStorageService::createSimpleStorageService(simple_storage0, {"/disk100"},
+                            {}, {})));
+
+    // Non-bufferized
+    ASSERT_NO_THROW(simple_storage_service_510 = simulation->add(
+                        wrench::SimpleStorageService::createSimpleStorageService(simple_storage1, {"/disk100", "/disk510"},
+                            {}, {})));
+
+    // Create a valid Compound Storage Service (using a non-bufferized storage service in this case) with a user-provided callback
+    ASSERT_NO_THROW(compound_storage_service = simulation->add(
+                        new wrench::CompoundStorageService(compound_storage, {simple_storage_service_510}, defaultStorageServiceSelection)));
+    
+    // Create a Controler
+    std::shared_ptr<wrench::ExecutionController> wms = nullptr;
+    ASSERT_NO_THROW(wms = simulation->add(
+                        new CompoundStorageServiceInterceptFunctionalityTestCtrl(this, compute)));
+
+    // Running a "run a single task1" simulation
+    ASSERT_NO_THROW(simulation->launch());
+
+    for (int i = 0; i < argc; i++)
+        free(argv[i]);
+    free(argv);
+}
+
+
+/**********************************************************************/
+/**  BASIC ERROR CASE  SIMULATION TEST                   **/
+/**********************************************************************/
+
+class CompoundStorageServiceErrorTestCtrl : public wrench::ExecutionController {
+
+public:
+    CompoundStorageServiceErrorTestCtrl(CompoundStorageServiceFunctionalTest *test,
+                                                  std::string hostname) : wrench::ExecutionController(hostname, "test"), test(test) {
+    }
+
+private:
+    CompoundStorageServiceFunctionalTest *test;
+
+    int main() {
+
+        auto job_manager = this->createJobManager();
+        
+    
+        // 1 - Copy from CSS to SS, using a file that was not created on CSS beforehand
+        auto jobCopyError = job_manager->createCompoundJob("jobCopyError");
+        auto fileCopyActionCSS_SS = jobCopyError->addFileCopyAction(
+            "fileCopySrcCSS_DstSS", 
+            wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500),
+            wrench::FileLocation::LOCATION(test->simple_storage_service_1000, "/disk1000/copy_from_css/", test->file_500)
+        );
+
+        job_manager->submitJob(jobCopyError, test->compute_service, {});
+
+        // 2 - Copy from SS to CSS, using a file that is too big to be allocated
+        auto jobCopySizeError = job_manager->createCompoundJob("jobCopySizeError");
+        simulation->createFile(wrench::FileLocation::LOCATION(test->simple_storage_service_1000, "/disk1000/", test->file_1000));
+        auto fileCopyActionSS_CSS = jobCopySizeError->addFileCopyAction(
+            "fileCopySrcSS_DstCSS", 
+            wrench::FileLocation::LOCATION(test->simple_storage_service_1000, "/disk1000/", test->file_1000),
+            wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1000)
+        );
+
+        job_manager->submitJob(jobCopySizeError, test->compute_service, {});
+
+        // 3 - Read from CSS, using a file that was not written/copied to it beforehand
+        auto jobReadError = job_manager->createCompoundJob("jobReadError");
+        auto fileReadActionCSS = jobReadError->addFileReadAction(
+            "fileReadActionCSS",
+            wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1000)
+        );
+
+        job_manager->submitJob(jobReadError, test->compute_service, {});
+
+        // 4 - Write to CSS, with a file too big to be allocated
+        auto jobWriteError = job_manager->createCompoundJob("jobWriteError");
+        auto fileWriteActionCSS = jobWriteError->addFileReadAction(
+            "fileWriteActionCSS",
+            wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1000)
+        );
+
+        job_manager->submitJob(jobWriteError, test->compute_service, {});
+
+        // 5 - Write to CSS, with a file too big to be allocated
+        auto jobDeleteError = job_manager->createCompoundJob("jobDeleteError");
+        auto fileDeleteActionCSS = jobDeleteError->addFileReadAction(
+            "fileDeleteActionCSS",
+            wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1000)
+        );
+
+        job_manager->submitJob(jobDeleteError, test->compute_service, {});
+
+
+        // 1
+        this->waitForNextEvent();
+        if (!jobCopyError->hasFailed())
+            throw std::runtime_error("Unexpected job state: " + jobCopyError->getStateAsString());
+        if (!std::dynamic_pointer_cast<wrench::NotAllowed>(fileCopyActionCSS_SS->getFailureCause()))
+            throw std::runtime_error("Did not receive a 'NotAllowed' failure cause as expected");
+
+        // 2
+        this->waitForNextEvent();
+        if (!jobCopySizeError->hasFailed())
+            throw std::runtime_error("Unexpected job state: " + jobCopySizeError->getStateAsString());
+        if (!std::dynamic_pointer_cast<wrench::StorageServiceNotEnoughSpace>(fileCopyActionSS_CSS->getFailureCause()))
+            throw std::runtime_error("Did not receive a 'StorageServiceNotEnoughSpace' failure cause as expected");
+        
+        // 3
+        this->waitForNextEvent();
+        if (!jobReadError->hasFailed())
+            throw std::runtime_error("Unexpected job state: " + jobReadError->getStateAsString());
+        if (!std::dynamic_pointer_cast<wrench::FileNotFound>(fileReadActionCSS->getFailureCause()))
+            throw std::runtime_error("Did not receive a 'FileNotFound' failure cause as expected");
+
+        // 4
+        this->waitForNextEvent();
+        if (!jobWriteError->hasFailed())
+            throw std::runtime_error("Unexpected job state: " + jobWriteError->getStateAsString());
+        if (!std::dynamic_pointer_cast<wrench::FileNotFound>(fileWriteActionCSS->getFailureCause()))
+            throw std::runtime_error("Did not receive a 'FileNotFound' failure cause as expected");
+
+        // 5
+        this->waitForNextEvent();
+        if (!jobDeleteError->hasFailed())
+            throw std::runtime_error("Unexpected job state: " + jobDeleteError->getStateAsString());
+        if (!std::dynamic_pointer_cast<wrench::FileNotFound>(fileDeleteActionCSS->getFailureCause()))
+            throw std::runtime_error("Did not receive a 'FileNotFound' failure cause as expected");
+
+        return 0;
+    }
+};
+
+TEST_F(CompoundStorageServiceFunctionalTest, BasicError) {
+    DO_TEST_WITH_FORK(do_BasicError_test);
+}
+
+void CompoundStorageServiceFunctionalTest::do_BasicError_test() {
+
+    // Create and initialize a simulation
+    auto simulation = wrench::Simulation::createSimulation();
+    // xbt_log_control_set("ker_engine.thres:debug");
+    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+    // xbt_log_control_set("wrench_core_compound_storage_system.thresh:debug");
+    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+    // xbt_log_control_set("wrench_core_storage_service.thres:info");
+
+    int argc = 1;
+    char **argv = (char **) calloc(argc, sizeof(char *));
+    argv[0] = strdup("unit_test");
+    //    argv[1] = strdup("--wrench-full-log");
+
+    ASSERT_NO_THROW(simulation->init(&argc, argv));
+
+    // Setting up the platform
+    ASSERT_NO_THROW(simulation->instantiatePlatform(platform_file_path));
+
+    // Get a hostname
+    auto compute = "ComputeHost";
+    auto simple_storage0 = "SimpleStorageHost0";
+    auto simple_storage1 = "SimpleStorageHost1";
+    auto compound_storage = "CompoundStorageHost";
+
+    // Create a Compute Service
+    ASSERT_NO_THROW(
+        compute_service = simulation->add(
+            new wrench::BareMetalComputeService(compute,
+                                                {std::make_pair(compute, std::make_tuple(wrench::ComputeService::ALL_CORES,
+                                                                                         wrench::ComputeService::ALL_RAM))},
+                                                {})));
+
+    // Create some simple storage services
+    // Bufferized
+    ASSERT_NO_THROW(simple_storage_service_1000 = simulation->add(
+                        wrench::SimpleStorageService::createSimpleStorageService(simple_storage0, {"/disk1000"},
+                        {{wrench::SimpleStorageServiceProperty::BUFFER_SIZE, "1000000"}}, {})));
+
+    // Non-bufferized
+    ASSERT_NO_THROW(simple_storage_service_100 = simulation->add(
+                        wrench::SimpleStorageService::createSimpleStorageService(simple_storage0, {"/disk100"},
+                            {}, {})));
+
+    // Non-bufferized
+    ASSERT_NO_THROW(simple_storage_service_510 = simulation->add(
+                        wrench::SimpleStorageService::createSimpleStorageService(simple_storage1, {"/disk100", "/disk510"},
+                            {}, {})));
+
+    // Create a valid Compound Storage Service (using a non-bufferized storage service in this case) with a user-provided callback
+    // CAREFUL -> REUSING CALLBACK FROM PREVIOUS TEST 
+    ASSERT_NO_THROW(compound_storage_service = simulation->add(
+                        new wrench::CompoundStorageService(compound_storage, {simple_storage_service_510}, defaultStorageServiceSelection)));
+    
+    // Create a Controler
+    std::shared_ptr<wrench::ExecutionController> wms = nullptr;
+    ASSERT_NO_THROW(wms = simulation->add(
+                        new CompoundStorageServiceErrorTestCtrl(this, compute)));
+
+    // Running a "run a single task1" simulation
+    ASSERT_NO_THROW(simulation->launch());
+
+    for (int i = 0; i < argc; i++)
+        free(argv[i]);
+    free(argv);
+}


### PR DESCRIPTION
This PR adds a `CompoundStorageService`, along with a few minor updates in `FileLocation`, `StorageService` and `Simulation` classes, in order to accommodate the new features.

A `CompoundStorageService` (CSS) is a storage aggregation service: at instantiation, instead of providing a set of mount points from a given host, you provide a set of `StorageService` (typically `SimpleStorageService`, bufferized or not), and you can refer to the CSS in `FileLocation` used by I/O actions of jobs, while deferring the actual choice of underlying `StorageService` to a later point.

In that regard, two "modes" of operation are proposed:

- if a so-called "storage selection" callback is provided by the user upon creating the CSS, then when messages are sent to the CSS during simulation run, for instance during file read/write/copy/delete operations, the CSS will use the callback to select an appropriate underlying storage service and keep trace of which file was placed where (in a `FileRegistryService` fashion).
- if no callback is provided, the CSS is unable to deal with IO-related requests, but it is expected that the user has implemented a specific scheduler which looks into every IO action *before* executing them, and updates them accordingly when it notices that a CSS is in use.

Main changes in existing code:

- `Simulation` : prevent someone from using stageFile() on a CSS (files can't be allocated to a CSS directly, it has no storage itself)
- `FileLocation`: Adding two setters for mount_point and storage_service so that a scheduler can update the FileLocation inside an I/O action *during* the execution of the simulation.
- `StorageService`: 
    - `writeFile(const std::shared_ptr<FileLocation> &location)` needs to know the buffer_size of the storage service associated with the `FileLocation` of the written file. When using a CSS in the `FileLocation`, it will default to the CSS's own buffer_size, instead of using the correct buffer_size of the underlying storage service, because it doesn't know that the `StorageServiceFileWriteRequestMessage` will be intercepted by a CSS. In order to bypass this issue we use the `location` in the answer message to update the buffer_size (there should be no effect in the absence of a CSS... and `location` contains the correct StorageService when using a CSS).
    - `copyFile(const std::shared_ptr<FileLocation> &src_location, const std::shared_ptr<FileLocation> &dst_location)` now checks whether or not a CSS is involved as src or dst in the copy, and makes sure that the request message will always go to the CSS if that's the case.

Basic functional tests are also provided.