### PR TITLE
Update in CompoundStorageService

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ set(HEADER_FILES
         include/wrench/services/storage/compound/CompoundStorageService.h
         include/wrench/services/storage/compound/CompoundStorageServiceProperty.h
         include/wrench/services/storage/compound/CompoundStorageServiceMessagePayload.h
+        include/wrench/services/storage/compound/CompoundStorageServiceMessage.h
         include/wrench/services/storage/storage_helpers/FileLocation.h
 #        include/wrench/services/memory/Block.h
 #        include/wrench/services/memory/MemoryManager.h
@@ -326,6 +327,7 @@ set(SOURCE_FILES
         src/wrench/services/storage/compound/CompoundStorageService.cpp
         src/wrench/services/storage/compound/CompoundStorageServiceProperty.cpp
         src/wrench/services/storage/compound/CompoundStorageServiceMessagePayload.cpp
+        src/wrench/services/storage/compound/CompoundStorageServiceMessage.cpp
         src/wrench/services/storage/storage_helper_classes/FileLocation.cpp
         src/wrench/services/storage/storage_helper_classes/FileTransferThread.cpp
         include/wrench/services/storage/storage_helpers/FileTransferThreadMessage.h

--- a/include/wrench/services/storage/StorageService.h
+++ b/include/wrench/services/storage/StorageService.h
@@ -393,6 +393,16 @@ namespace wrench {
          */
         virtual double getTotalFreeSpaceAtPath(const std::string &path);
 
+        /** Service free space tracing (doesn't incur simulated overhead) */
+        /**
+         *  @brief Get the storage service's total free space (no simulated overhead)
+         *  @return Current free space in bytes
+         * 
+        */
+        virtual double traceTotalFreeSpace() {
+            throw std::runtime_error("StorageService::traceTotalFreeSpace: should have been overridden by derived class");
+        }
+
         /**
          * @brief Get the storage's service base root path
          * @return a path

--- a/include/wrench/services/storage/compound/CompoundStorageService.h
+++ b/include/wrench/services/storage/compound/CompoundStorageService.h
@@ -16,6 +16,7 @@
 #include "wrench/simgrid_S4U_util/S4U_PendingCommunication.h"
 #include "wrench/services/storage/compound/CompoundStorageServiceProperty.h"
 #include "wrench/services/storage/compound/CompoundStorageServiceMessagePayload.h"
+#include "wrench/services/storage/compound/CompoundStorageServiceMessage.h"
 
 namespace wrench {
 
@@ -24,8 +25,43 @@ namespace wrench {
      */
     using StorageSelectionStrategyCallback = std::function<std::shared_ptr<FileLocation>(
             const std::shared_ptr<DataFile> &,
-            const std::set<std::shared_ptr<StorageService>> &,
-            const std::map<std::shared_ptr<DataFile>, std::shared_ptr<FileLocation>> &)>;
+            const std::map<std::string, std::vector<std::shared_ptr<StorageService>>> &,
+            const std::map<std::shared_ptr<DataFile>, std::vector<std::shared_ptr<FileLocation>>> &,
+            const std::vector<std::shared_ptr<FileLocation>>& previous_allocations)>;
+
+    /**
+     * @brief Enum for IO actions in traces
+    */
+    enum class IOAction: std::uint8_t {
+        ReadStart = 1, 
+        ReadEnd = 2, 
+        WriteStart = 3, 
+        WriteEnd = 4, 
+        CopyToStart = 5, 
+        CopyToEnd = 6, 
+        CopyFromStart = 7, 
+        CopyFromEnd = 8, 
+        DeleteStart = 9, 
+        DeleteEnd = 10,
+        None = 11,
+    };
+
+    struct DiskUsage {
+        std::shared_ptr<StorageService> service;
+        double free_space;
+        std::string file_name;
+        double load;        // not actually used so far
+    };
+
+    /**
+     * @brief Structure for tracing file allocations for each job 
+     */
+    struct AllocationTrace {
+        double ts;
+        IOAction act;
+        std::vector<DiskUsage> disk_usage;                              // new usage stats for updated disks
+        std::vector<std::shared_ptr<FileLocation>> internal_locations;  
+    };
 
     /**
      * @brief An abstract storage service which holds a collection of concrete storage services (eg. 
@@ -34,11 +70,10 @@ namespace wrench {
      *        action (read, write, copy, etc) until a later time in the simulation, rather than during
      *        job definition. A typical use for the CompoundStorageService is to select a definitive
      *        SimpleStorageService for each action of a job during its scheduling in a BatchScheduler class.
-     *        This service is able to receive and handle the same messages as any standard storage service 
-     *        (File Read/Write/Delete/Copy/Lookup requests), but will always answer that it is unable to 
-     *        process any of these requests, which should be addressed directly to the correct underlying 
-     *        storage service. (A possible future patch could give it the ability to automatically forward 
-     *        said request to one of the underlying storage services).
+     *        This should never receive messages for I/O operations, as any standard storage service 
+     *        (File Read/Write/Delete/Copy/Lookup requests), instead, it overides the main functions of 
+     *        StorageService (readFile / writeFile /...) and will craft messages intended for one or many of 
+     *        its underlying storage services.
      */
     class CompoundStorageService : public StorageService {
     public:
@@ -139,14 +174,49 @@ namespace wrench {
         /**
          * @brief Method to return the collection of known StorageServices
          */
-        std::set<std::shared_ptr<StorageService>> &getAllServices();
+        std::map<std::string, std::vector<std::shared_ptr<wrench::StorageService>>> &getAllServices();
 
-        std::shared_ptr<FileLocation> lookupFileLocation(const std::shared_ptr<DataFile> &file);
+        std::vector<std::shared_ptr<FileLocation>> lookupFileLocation(const std::shared_ptr<DataFile> &file, simgrid::s4u::Mailbox *answer_mailbox);
 
-        std::shared_ptr<FileLocation> lookupFileLocation(const std::shared_ptr<FileLocation> &location);
-
+        std::vector<std::shared_ptr<FileLocation>> lookupFileLocation(const std::shared_ptr<FileLocation> &location);
 
         bool hasFile(const std::shared_ptr<FileLocation> &location) override;
+
+        void writeFile(simgrid::s4u::Mailbox *answer_mailbox,
+                       const std::shared_ptr<FileLocation> &location,
+                       bool wait_for_answer) override;
+
+        void readFile(simgrid::s4u::Mailbox *answer_mailbox,
+                      const std::shared_ptr<FileLocation> &location,
+                      double num_bytes,
+                      bool wait_for_answer) override;
+
+        void deleteFile(simgrid::s4u::Mailbox *answer_mailbox,
+                        const std::shared_ptr<FileLocation> &location,
+                        bool wait_for_answer) override;
+
+        bool lookupFile(simgrid::s4u::Mailbox *answer_mailbox,
+                        const std::shared_ptr<FileLocation> &location) override;
+
+        /**
+         * @brief Intended to be called by StorageService::copyFile() when the use 
+         *        of a CSS is detected in a file copy.
+        */
+        static void copyFile(const std::shared_ptr<FileLocation> &src_location,
+                             const std::shared_ptr<FileLocation> &dst_location);
+        
+        void copyFileIamSource(const std::shared_ptr<FileLocation> &src_location,
+                             const std::shared_ptr<FileLocation> &dst_location);
+
+        void copyFileIamDestination(const std::shared_ptr<FileLocation> &src_location,
+                             const std::shared_ptr<FileLocation> &dst_location);
+
+        // Publicly accessible traces... (TODO: cleanup access to traces)
+        std::map<std::string, AllocationTrace> read_traces = {};
+        std::map<std::string, AllocationTrace> write_traces = {};
+        std::map<std::string, AllocationTrace> copy_traces = {};
+        std::map<std::string, AllocationTrace> delete_traces = {};
+        std::vector<std::pair<double, AllocationTrace>> internal_storage_use = {};
 
         /***********************/
         /** \endcond           */
@@ -166,7 +236,6 @@ namespace wrench {
 
         /** @brief Default property values **/
         WRENCH_PROPERTY_COLLECTION_TYPE default_property_values = {
-                {CompoundStorageServiceProperty::STORAGE_SELECTION_METHOD, "external"},
                 {CompoundStorageServiceProperty::CACHING_BEHAVIOR, "NONE"},
         };
 
@@ -189,12 +258,12 @@ namespace wrench {
                 {CompoundStorageServiceMessagePayload::FILE_READ_ANSWER_MESSAGE_PAYLOAD, 0},
                 {CompoundStorageServiceMessagePayload::FILE_WRITE_REQUEST_MESSAGE_PAYLOAD, 0},
                 {CompoundStorageServiceMessagePayload::FILE_WRITE_ANSWER_MESSAGE_PAYLOAD, 0},
+                {CompoundStorageServiceMessagePayload::STORAGE_SELECTION_PAYLOAD, 1024}
         };
 
         static unsigned long getNewUniqueNumber();
 
         bool processStopDaemonRequest(simgrid::s4u::Mailbox *ack_mailbox);
-
 
         /***********************/
         /** \endcond           */
@@ -205,32 +274,33 @@ namespace wrench {
 
         int main() override;
 
-        std::shared_ptr<FileLocation> lookupOrDesignateStorageService(const std::shared_ptr<DataFile> concrete_file_location);
+        std::vector<std::shared_ptr<FileLocation>> lookupOrDesignateStorageService(const std::shared_ptr<DataFile> concrete_file_location, simgrid::s4u::Mailbox *answer_mailbox);
 
-        std::shared_ptr<FileLocation> lookupOrDesignateStorageService(const std::shared_ptr<FileLocation> location);
+        std::vector<std::shared_ptr<FileLocation>> lookupOrDesignateStorageService(const std::shared_ptr<FileLocation> location);
+
+        bool processStorageSelectionMessage(const CompoundStorageAllocationRequestMessage* msg);
+
+        bool processStorageLookupMessage(const CompoundStorageLookupRequestMessage* msg);
 
         bool processNextMessage(SimulationMessage *message);
 
-        bool processFileDeleteRequest(StorageServiceFileDeleteRequestMessage *msg);
+        std::map<std::string, std::vector<std::shared_ptr<StorageService>>> storage_services = {};
 
-        bool processFileLookupRequest(StorageServiceFileLookupRequestMessage *msg);
-
-        bool processFileCopyRequest(StorageServiceFileCopyRequestMessage *msg);
-
-        bool processFileWriteRequest(StorageServiceFileWriteRequestMessage *msg);
-
-        bool processFileReadRequest(StorageServiceFileReadRequestMessage *msg);
-
-        std::set<std::shared_ptr<StorageService>> storage_services = {};
-
-        std::map<std::shared_ptr<DataFile>, std::shared_ptr<FileLocation>> file_location_mapping = {};
+        std::map<std::shared_ptr<DataFile>, std::vector<std::shared_ptr<FileLocation>>> file_location_mapping = {};
 
         StorageSelectionStrategyCallback storage_selection;
 
-        bool isStorageSelectionUserProvided;
+        /**
+         * @brief Chunk size for file stripping
+         *        Should usually be user-provided, or will be 
+         *        set to the smallest disk size as default.
+        */
+        double max_chunk_size = 0;
 
-        /** @brief File systems */// TODO: Is this really needed now that file_systems are no longer in StorageService.h?
-        std::map<std::string, std::unique_ptr<LogicalFileSystem>> file_systems;
+        /**
+         * @brief Dirty log tracing method (needs to be improved)
+        */
+        void traceInternalStorageUse(IOAction action, const std::vector<std::shared_ptr<FileLocation>> &locations = {});
     };
 
 };// namespace wrench

--- a/include/wrench/services/storage/compound/CompoundStorageServiceMessage.h
+++ b/include/wrench/services/storage/compound/CompoundStorageServiceMessage.h
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2017. The WRENCH Team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+
+#ifndef WRENCH_COMPOUNDSTORAGESERVICEMESSAGE_H
+#define WRENCH_COMPOUNDSTORAGESERVICEMESSAGE_H
+
+
+#include <memory>
+#include <utility>
+
+#include <wrench/services/storage/StorageServiceMessage.h>
+#include <wrench/data_file/DataFile.h>
+
+namespace wrench {
+
+    /***********************/
+    /** \cond INTERNAL     */
+    /***********************/
+
+    /**
+     * @brief Top-level class for messages received/sent by a StorageService
+     */
+    class CompoundStorageServiceMessage : public StorageServiceMessage {
+    protected:
+        CompoundStorageServiceMessage(double payload);
+    };
+
+
+    /**
+     * @brief A message sent to a CompoundStorageService to request a storage allocation for a file
+     */
+    class CompoundStorageAllocationRequestMessage : public CompoundStorageServiceMessage {
+    public:
+        CompoundStorageAllocationRequestMessage(simgrid::s4u::Mailbox *answer_mailbox, std::shared_ptr<DataFile> file, double payload);
+
+        /** @brief Mailbox to which the answer message should be sent */
+        simgrid::s4u::Mailbox *answer_mailbox;
+        /** @brief The path */
+        std::shared_ptr<DataFile> file;
+    };
+
+    /**
+     * @brief A message sent by a StorageService in answer to a storage selection request
+     */
+    class CompoundStorageAllocationAnswerMessage : public CompoundStorageServiceMessage {
+    public:
+        CompoundStorageAllocationAnswerMessage(std::vector<std::shared_ptr<FileLocation>> locations, double payload);
+
+        /** @brief Known or newly allocated FileLocations for requested file */
+        std::vector<std::shared_ptr<FileLocation>> locations;
+    };
+
+    /**
+     * @brief A message sent to a CompoundStorageService to request a storage allocation for a file
+     */
+    class CompoundStorageLookupRequestMessage : public CompoundStorageServiceMessage {
+    public:
+        CompoundStorageLookupRequestMessage(simgrid::s4u::Mailbox *answer_mailbox, std::shared_ptr<DataFile> file, double payload);
+
+        /** @brief Mailbox to which the answer message should be sent */
+        simgrid::s4u::Mailbox *answer_mailbox;
+        /** @brief The path */
+        std::shared_ptr<DataFile> file;
+    };
+
+    /**
+     * @brief A message sent by a StorageService in answer to a storage selection request
+     */
+    class CompoundStorageLookupAnswerMessage : public CompoundStorageServiceMessage {
+    public:
+        CompoundStorageLookupAnswerMessage(std::vector<std::shared_ptr<FileLocation>> locations, double payload);
+
+        /** @brief Known FileLocations for requested file */
+        std::vector<std::shared_ptr<FileLocation>> locations;
+    };
+
+
+    /***********************/
+    /** \endcond INTERNAL     */
+    /***********************/
+    
+}// namespace wrench
+
+
+#endif//WRENCH_COMPOUNDSTORAGESERVICEMESSAGE_H

--- a/include/wrench/services/storage/compound/CompoundStorageServiceMessagePayload.h
+++ b/include/wrench/services/storage/compound/CompoundStorageServiceMessagePayload.h
@@ -12,6 +12,7 @@
 #define WRENCH_COMPOUNDSTORAGESERVICEMESSAGEPAYLOAD_H
 
 #include "wrench/services/storage/StorageServiceMessagePayload.h"
+#include "wrench/services/ServiceMessagePayload.h"
 
 namespace wrench {
 
@@ -19,7 +20,10 @@ namespace wrench {
     * @brief Configurable message payloads for a CompoundStorageService
     */
     class CompoundStorageServiceMessagePayload : public StorageServiceMessagePayload {
-    public:
+
+        public:
+            /** @brief The number of bytes in the control message sent by the daemon to answer a storage selection request **/
+            DECLARE_MESSAGEPAYLOAD_NAME(STORAGE_SELECTION_PAYLOAD);
     };
 
 };// namespace wrench

--- a/include/wrench/services/storage/compound/CompoundStorageServiceProperty.h
+++ b/include/wrench/services/storage/compound/CompoundStorageServiceProperty.h
@@ -26,7 +26,7 @@ namespace wrench {
          *         CompoundStorageService being passive. A future option would be
          *         to have the CSS take the decision upon receiving an IO request.
          */
-        DECLARE_PROPERTY_NAME(STORAGE_SELECTION_METHOD);
+        DECLARE_PROPERTY_NAME(MAX_ALLOCATION_CHUNK_SIZE);
     };
 
 };// namespace wrench

--- a/include/wrench/services/storage/simple/SimpleStorageService.h
+++ b/include/wrench/services/storage/simple/SimpleStorageService.h
@@ -102,6 +102,8 @@ namespace wrench {
 
         double getTotalSpace() override;
 
+        double traceTotalFreeSpace() override;
+
         virtual std::string getBaseRootPath() override;
 
 

--- a/src/wrench/services/storage/StorageService.cpp
+++ b/src/wrench/services/storage/StorageService.cpp
@@ -441,6 +441,11 @@ namespace wrench {
             throw std::invalid_argument("StorageService::copyFile(): src and dst locations should be for the same file");
         }
 
+        if (std::dynamic_pointer_cast<CompoundStorageService>(src_location->getStorageService()) or 
+            std::dynamic_pointer_cast<CompoundStorageService>(dst_location->getStorageService())) {
+            return CompoundStorageService::copyFile(src_location, dst_location); 
+        }
+
         assertServiceIsUp(src_location->getStorageService());
         assertServiceIsUp(dst_location->getStorageService());
 
@@ -455,9 +460,9 @@ namespace wrench {
         //        }
 
         simgrid::s4u::Mailbox *mailbox_to_contact;
-        if (dst_is_non_bufferized and !(std::dynamic_pointer_cast<CompoundStorageService>(src_location->getStorageService()))) {
+        if (dst_is_non_bufferized) {
             mailbox_to_contact = dst_location->getStorageService()->mailbox;
-        } else if (src_is_non_bufferized and !(std::dynamic_pointer_cast<CompoundStorageService>(dst_location->getStorageService()))) {
+        } else if (src_is_non_bufferized) {
             mailbox_to_contact = src_location->getStorageService()->mailbox;
         } else {
             mailbox_to_contact = dst_location->getStorageService()->mailbox;
@@ -469,7 +474,6 @@ namespace wrench {
         src_location->getStorageService()->simulation->getOutput().addTimestampFileCopyStart(Simulation::getCurrentSimulatedDate(), file,
                                                                                              src_location,
                                                                                              dst_location);
-
         S4U_Mailbox::putMessage(
                 mailbox_to_contact,
                 new StorageServiceFileCopyRequestMessage(
@@ -482,10 +486,11 @@ namespace wrench {
         // Wait for a reply
         std::unique_ptr<SimulationMessage> message = nullptr;
 
+
         auto msg = S4U_Mailbox::getMessage<StorageServiceFileCopyAnswerMessage>(answer_mailbox);
 
-
         if (msg->failure_cause) {
+            WRENCH_DEBUG("%s", msg->failure_cause->toString().c_str());
             throw ExecutionException(std::move(msg->failure_cause));
         }
     }

--- a/src/wrench/services/storage/compound/CompoundStorageService.cpp
+++ b/src/wrench/services/storage/compound/CompoundStorageService.cpp
@@ -1,4 +1,6 @@
 #include <wrench/services/storage/compound/CompoundStorageService.h>
+
+#include "wrench/services/storage/compound/CompoundStorageServiceMessage.h"
 #include <wrench/services/ServiceMessage.h>
 #include <wrench/services/storage/simple/SimpleStorageService.h>
 #include "wrench/services/storage/StorageServiceMessage.h"
@@ -14,8 +16,7 @@ WRENCH_LOG_CATEGORY(wrench_core_compound_storage_system,
                     "Log category for Compound Storage Service");
 
 namespace wrench {
-
-
+        
     /** 
      *  @brief Default StorageSelectionStrategyCallback: strategy used by the CompoundStorageService 
      *         when no strategy is provided at instanciation. By default, it returns a nullptr, which 
@@ -29,10 +30,11 @@ namespace wrench {
     */
     std::shared_ptr<FileLocation> nullptrStorageServiceSelection(
             const std::shared_ptr<DataFile> &file,
-            const std::set<std::shared_ptr<StorageService>> &resources,
-            const std::map<std::shared_ptr<DataFile>, std::shared_ptr<FileLocation>> &mapping) {
+            const std::map<std::string, std::vector<std::shared_ptr<StorageService>>> &resources,
+            const std::map<std::shared_ptr<DataFile>, std::vector<std::shared_ptr<FileLocation>>> &mapping,
+            const std::vector<std::shared_ptr<FileLocation>> &previous_allocations) {
         return nullptr;
-    }
+    };
 
 
     /** 
@@ -93,9 +95,11 @@ namespace wrench {
             WRENCH_MESSAGE_PAYLOADCOLLECTION_TYPE messagepayload_list,
             const std::string &suffix) : StorageService(hostname,
                                                         "compound_storage" + suffix) {
+
+                                                             
         this->setProperties(this->default_property_values, std::move(property_list));
         this->setMessagePayloads(this->default_messagepayload_values, std::move(messagepayload_list));
-
+        
         if (storage_services.empty()) {
             throw std::invalid_argument("Got an empty list of StorageServices for CompoundStorageService."
                                         "Must specify at least one valid StorageService");
@@ -114,24 +118,24 @@ namespace wrench {
                                         "In the current state of the implementation this is currently not allowed");
         }
 
-        /* // This should eventually be allowed, currently trying to fix it.
-            if (std::any_of(storage_services.begin(), storage_services.end(), [](const auto& elem){ return elem->isBufferized(); })) {
-                throw std::invalid_argument("CompoundStorageService can't deal with bufferized StorageServices");
+        for (const auto& storage_service : storage_services) {
+            if (this->storage_services.find(storage_service->getHostname()) != this->storage_services.end()) {
+                this->storage_services[storage_service->getHostname()].push_back(storage_service);
+            } else {
+                this->storage_services[storage_service->getHostname()] = std::vector<std::shared_ptr<wrench::StorageService>>{storage_service};
             }
-            */
-
-        // CSS should be non-bufferized, as it actually doesn't copy / transfer anything
-        // and this allows it to receive message requests for copy (otherwise, src storage service might receive it)
-        this->storage_services = storage_services;
+        }
         this->storage_selection = std::move(storage_selection);
-        this->isStorageSelectionUserProvided = storage_selection_user_provided;
 
-        // Dummy logical file system
-        this->file_systems[LogicalFileSystem::DEV_NULL] = LogicalFileSystem::createLogicalFileSystem(
-                this->getHostname(),
-                this,
-                LogicalFileSystem::DEV_NULL,
-                this->getPropertyValueAsString(wrench::StorageServiceProperty::CACHING_BEHAVIOR));
+        if (property_list.find(wrench::CompoundStorageServiceProperty::MAX_ALLOCATION_CHUNK_SIZE) == property_list.end()) {
+            // If MAX_ALLOCATION_CHUNK_SIZE was not probided, update it now that we have validated the SSS list
+            // (Set as smallest disk capacity in bytes for instance ?)
+            // TODO
+            // this->setProperty(CompoundStorageServiceProperty::MAX_ALLOCATION_CHUNK_SIZE, "2000000B");
+        }   
+
+        this->max_chunk_size = this->getPropertyValueAsSizeInByte(CompoundStorageServiceProperty::MAX_ALLOCATION_CHUNK_SIZE);
+        this->traceInternalStorageUse(IOAction::None);
     }
 
 
@@ -146,13 +150,12 @@ namespace wrench {
         std::string message = "Compound Storage Service " + this->getName() + "  starting on host " + this->getHostname();
         WRENCH_INFO("%s", message.c_str());
 
-        WRENCH_INFO("Registered underlying storage services:");
-        for (const auto &ss: this->storage_services) {
-            message = " - " + ss->process_name + " on " + ss->getHostname();
-            WRENCH_INFO("%s", message.c_str());
-            //            for (const auto &mnt: ss->getMountPoints()) {
-            //                WRENCH_INFO("  - %s", mnt.c_str());
-            //            }
+        WRENCH_INFO("CSS - Registered underlying storage services:");
+        for (const auto &storage_server: this->storage_services) {
+            for (const auto& service : storage_server.second) {
+                message = " - " + service->process_name + " on " + service->getHostname();
+                WRENCH_INFO("%s", message.c_str());
+            }
         }
 
         /** Main loop **/
@@ -214,53 +217,163 @@ namespace wrench {
      * @return false if the daemon should terminate
      */
     bool CompoundStorageService::processNextMessage(SimulationMessage *message) {
-        WRENCH_INFO("Got a [%s] message", message->getName().c_str());
+        WRENCH_INFO("CSS::Got a [%s] message", message->getName().c_str());
 
         if (auto msg = dynamic_cast<ServiceStopDaemonMessage *>(message)) {
             return processStopDaemonRequest(msg->ack_mailbox);
 
-        } else if (auto msg = dynamic_cast<StorageServiceFileDeleteRequestMessage *>(message)) {
-            return processFileDeleteRequest(msg);
+        } else if (auto msg = dynamic_cast<CompoundStorageAllocationRequestMessage *>(message)) {
+            WRENCH_INFO("Calling processStorageSelectionMessage for file :  %s", msg->file->getID().c_str());
+            return processStorageSelectionMessage(msg);
 
-        } else if (auto msg = dynamic_cast<StorageServiceFileLookupRequestMessage *>(message)) {
-            return processFileLookupRequest(msg);
-
-        } else if (auto msg = dynamic_cast<StorageServiceFileWriteRequestMessage *>(message)) {
-            return processFileWriteRequest(msg);
-
-        } else if (auto msg = dynamic_cast<StorageServiceFileReadRequestMessage *>(message)) {
-            return processFileReadRequest(msg);
-
-        } else if (auto msg = dynamic_cast<StorageServiceFileCopyRequestMessage *>(message)) {
-            return processFileCopyRequest(msg);
+        } else if (auto msg = dynamic_cast<CompoundStorageLookupRequestMessage *>(message)) {
+            WRENCH_INFO("Calling processStorageLookupMessage for file :  %s", msg->file->getID().c_str());
+            return processStorageLookupMessage(msg);
 
         } else {
             throw std::runtime_error(
-                    "CompoundStorageService::processNextMessage(): Unexpected [" + message->getName() + "] message." +
+                    "CSS::processNextMessage(): Unexpected [" + message->getName() + "] message." +
                     "This is only an abstraction layer and it can't be used as an actual storage service");
         }
     }
+
+
+    bool CompoundStorageService::processStorageSelectionMessage(const CompoundStorageAllocationRequestMessage* msg) {
+
+        WRENCH_INFO("CSS::processStorageSelectionMessage()");
+
+        auto file = msg->file;   
+
+
+        if (this->file_location_mapping.find(file) != this->file_location_mapping.end()) {
+
+            WRENCH_INFO("CSS::lookupOrDesignateStorageService: File %s already known by CSS", file->getID().c_str());
+            
+            S4U_Mailbox::dputMessage(
+                msg->answer_mailbox,
+                new CompoundStorageAllocationAnswerMessage(
+                        this->file_location_mapping[file],
+                        this->getMessagePayloadValue(
+                        CompoundStorageServiceMessagePayload::STORAGE_SELECTION_PAYLOAD)));
+            return true;
+        }
+
+
+        std::vector<std::shared_ptr<DataFile>> parts = {};
+        auto file_size = file->getSize();
+        auto file_name = file->getID();
+
+        // Stripping case
+        if (file_size > this->max_chunk_size) {
+            WRENCH_INFO("CSS::lookupOrDesignateStorageService(): Stripping file");
+            double remaining = file_size;
+            auto part_id = 0;
+            while (remaining - this->max_chunk_size > DBL_EPSILON) {
+                parts.push_back(
+                    this->simulation->addFile(file_name + "_part_" + std::to_string(part_id), this->max_chunk_size));
+                    // std::make_shared<DataFile>(file_name + "_part_" + std::to_string(part_id), this->max_chunk_size));
+                part_id++;
+                remaining -= this->max_chunk_size;
+            }
+            parts.push_back(this->simulation->addFile(file_name + "_part_" + std::to_string(part_id), remaining));
+            // parts.push_back(std::make_shared<DataFile>(file_name + "_part_" + std::to_string(part_id), remaining));
+        } else {
+            parts.push_back(file);
+        }
+
+        // Resolve allocations for all parts (possibly only one part)
+        std::vector<std::shared_ptr<FileLocation>> designated_locations = {};
+        for (const auto& part : parts) {
+            WRENCH_INFO("CSS::lookupOrDesignateStorageService(): File %s NOT already known by CSS", part->getID().c_str());
+            auto new_loc = this->storage_selection(part, this->storage_services, this->file_location_mapping, designated_locations);
+            if (new_loc) {
+                new_loc->getStorageService()->reserveSpace(new_loc);
+                designated_locations.push_back(new_loc);
+            } else {
+                WRENCH_INFO("CSS::lookupOrDesignateStorageService(): File %s (or parts) could not be placed on any ss", file->getID().c_str());
+                designated_locations = {};
+                break;
+                // throw ExecutionException(std::make_shared<StorageServiceNotEnoughSpace>(file, this->getSharedPtr<CompoundStorageService>()));
+            }
+        }
+
+        if (!designated_locations.empty()) {
+            this->file_location_mapping[file] = designated_locations;
+            WRENCH_INFO("CSS::lookupOrDesignateStorageService(): Local mapping updated");
+        }
+        
+        S4U_Mailbox::dputMessage(
+                msg->answer_mailbox,
+                new CompoundStorageAllocationAnswerMessage(
+                        designated_locations,
+                        this->getMessagePayloadValue(
+                        CompoundStorageServiceMessagePayload::STORAGE_SELECTION_PAYLOAD)));
+
+        WRENCH_INFO("CSS::lookupOrDesignateStorageService(): Answer sent");
+
+        return true;
+
+    }
+
+    bool CompoundStorageService::processStorageLookupMessage(const CompoundStorageLookupRequestMessage* msg) {
+        
+        WRENCH_INFO("CSS::processStorageLookupMessage()");
+
+        auto file = msg->file;
+
+        WRENCH_INFO("CSS::lookupFileLocation(): For file %s", file->getID().c_str());
+
+        if (this->file_location_mapping.find(file) == this->file_location_mapping.end()) {
+            WRENCH_INFO("CSS::lookupFileLocation(): File %s is not known by this CompoundStorageService", file->getID().c_str());
+
+            S4U_Mailbox::dputMessage(
+                msg->answer_mailbox,
+                new CompoundStorageLookupAnswerMessage(
+                        std::vector<std::shared_ptr<FileLocation>>(),
+                        this->getMessagePayloadValue(
+                        CompoundStorageServiceMessagePayload::STORAGE_SELECTION_PAYLOAD)));
+
+        } else {
+            auto mapped_locations = this->file_location_mapping[file];
+            for (const auto& loc : mapped_locations) {
+                WRENCH_INFO("CSS::lookupFileLocation(): File %s is known by this CompoundStorageService and associated to storage service %s",
+                         loc->getFile()->getID().c_str(),
+                         loc->getStorageService()->getName().c_str());
+            }
+
+            S4U_Mailbox::dputMessage(
+                msg->answer_mailbox,
+                new CompoundStorageLookupAnswerMessage(
+                        mapped_locations,
+                        this->getMessagePayloadValue(
+                        CompoundStorageServiceMessagePayload::STORAGE_SELECTION_PAYLOAD)));
+        }
+
+        return true;
+    }
+
 
     /**
      * @brief Lookup for a DataFile in the internal file mapping of the CompoundStorageService (a simplified FileRegistry)
      *
      * @param file: the file of interest
      * 
-     * @return A shared_ptr on a FileLocation if the DataFile is known to the CompoundStorageService or nullptr if it's not.
+     * @return A vector of shared_ptr on a FileLocation if the DataFile is known to the CompoundStorageService or empty vector if it's not.
      */
-    std::shared_ptr<FileLocation> CompoundStorageService::lookupFileLocation(const std::shared_ptr<DataFile> &file) {
-        WRENCH_DEBUG("lookupFileLocation: For file %s", file->getID().c_str());
+    std::vector<std::shared_ptr<FileLocation>> CompoundStorageService::lookupFileLocation(const std::shared_ptr<DataFile> &file, simgrid::s4u::Mailbox *answer_mailbox) {
 
-        if (this->file_location_mapping.find(file) == this->file_location_mapping.end()) {
-            WRENCH_DEBUG("lookupFileLocation: File %s is not known by this CompoundStorageService", file->getID().c_str());
-            return nullptr;
-        } else {
-            auto mapped_location = this->file_location_mapping[file];
-            WRENCH_DEBUG("lookupFileLocation: File %s is known by this CompoundStorageService and associated to storage service %s",
-                         mapped_location->getFile()->getID().c_str(),
-                         mapped_location->getStorageService()->getName().c_str());
-            return mapped_location;
-        }
+        WRENCH_INFO("CSS::lookupFileLocation() - DataFile + Mailbox");
+
+        S4U_Mailbox::putMessage(this->mailbox,
+                                new CompoundStorageLookupRequestMessage(
+                                        answer_mailbox,
+                                        file,
+                                        this->getMessagePayloadValue(
+                                                CompoundStorageServiceMessagePayload::STORAGE_SELECTION_PAYLOAD)));
+
+        auto msg = S4U_Mailbox::getMessage<CompoundStorageLookupAnswerMessage>(answer_mailbox, this->network_timeout, "CSS::lookupFileLocation(): Received a totally");
+
+        return msg->locations;
     }
 
     /** 
@@ -271,8 +384,17 @@ namespace wrench {
      *
      *  @return A shared_ptr on a FileLocation if the DataFile is known to the CompoundStorageService or nullptr if it's not.
      */
-    std::shared_ptr<FileLocation> CompoundStorageService::lookupFileLocation(const std::shared_ptr<FileLocation> &location) {
-        return this->lookupFileLocation(location->getFile());
+    std::vector<std::shared_ptr<FileLocation>> CompoundStorageService::lookupFileLocation(const std::shared_ptr<FileLocation> &location) {
+
+        WRENCH_INFO("CSS::lookupFileLocation() - FileLocation");
+        
+        auto temp_mailbox = S4U_Mailbox::getTemporaryMailbox();
+
+        auto locations = this->lookupFileLocation(location->getFile(), temp_mailbox);
+
+        S4U_Mailbox::retireTemporaryMailbox(temp_mailbox);
+
+        return locations;
     }
 
 
@@ -281,33 +403,25 @@ namespace wrench {
      *         try to allocate the file on one of the underlying storage services, using the user-provided 'storage_selection'
      *         callback.
      * 
-     *  @param concrete_file_location: the file of interest
+     *  @param file the file of interest
      *
-     *  @return A shared_ptr on a FileLocation if the DataFile is known to the CompoundStorageService or could be allocated
-     *          or nullptr if it's not.
+     *  @return A vector of shared_ptr on a FileLocation if the DataFile is known to the CompoundStorageService or could be allocated
+     *          or empty vector if it's not / could not be allocated.
      */
-    std::shared_ptr<FileLocation> CompoundStorageService::lookupOrDesignateStorageService(const std::shared_ptr<DataFile> concrete_file_location) {
-        if (this->lookupFileLocation(concrete_file_location)) {
-            WRENCH_DEBUG("lookupOrDesignateStorageService: File %s already known by CSS", concrete_file_location->getID().c_str());
-            return this->file_location_mapping[concrete_file_location];
-        }
+    std::vector<std::shared_ptr<FileLocation>> CompoundStorageService::lookupOrDesignateStorageService(const std::shared_ptr<DataFile> file, simgrid::s4u::Mailbox *answer_mailbox) {
 
-        WRENCH_DEBUG("lookupOrDesignateStorageService: File %s NOT already known by CSS", concrete_file_location->getID().c_str());
-        auto designatedLocation = this->storage_selection(concrete_file_location, this->storage_services, this->file_location_mapping);
+        WRENCH_INFO("CSS::lookupOrDesignateStorageService() - DataFile + mailbox");
 
-        if (!designatedLocation) {
-            WRENCH_DEBUG("lookupOrDesignateStorageService: File %s could not be placed on any ss", concrete_file_location->getID().c_str());
-        } else {
-            WRENCH_DEBUG("lookupOrDesignateStorageService: Registering file %s on storage service %s, at path %s",
-                         designatedLocation->getFile()->getID().c_str(),
-                         designatedLocation->getStorageService()->getName().c_str(),
-                         designatedLocation->getPath().c_str());
+        S4U_Mailbox::putMessage(this->mailbox,
+                                new CompoundStorageAllocationRequestMessage(
+                                        answer_mailbox,
+                                        file,
+                                        this->getMessagePayloadValue(
+                                                CompoundStorageServiceMessagePayload::STORAGE_SELECTION_PAYLOAD)));
 
-            // Supposing (and it better be true) that DataFiles are unique throught a given simulation run, even among various jobs.
-            this->file_location_mapping[designatedLocation->getFile()] = designatedLocation;
-        }
-
-        return designatedLocation;
+        auto msg = S4U_Mailbox::getMessage<CompoundStorageAllocationAnswerMessage>(answer_mailbox, this->network_timeout, "StorageService::writeFile(): Received a totally");
+        
+        return msg->locations;
     }
 
     /**
@@ -320,278 +434,668 @@ namespace wrench {
      *  @return A shared_ptr on a FileLocation if the DataFile is known to the CompoundStorageService or could be allocated
      *          or nullptr if it's not.
      */
-    std::shared_ptr<FileLocation> CompoundStorageService::lookupOrDesignateStorageService(const std::shared_ptr<FileLocation> location) {
-        return this->lookupOrDesignateStorageService(location->getFile());
+    std::vector<std::shared_ptr<FileLocation>> CompoundStorageService::lookupOrDesignateStorageService(const std::shared_ptr<FileLocation> location) {
+        
+        WRENCH_INFO("CSS::lookupOrDesignateStorageService() - FileLocation");
+
+        auto temp_mailbox = S4U_Mailbox::getTemporaryMailbox();
+        
+        auto locations = this->lookupOrDesignateStorageService(location->getFile(), temp_mailbox);
+
+        S4U_Mailbox::retireTemporaryMailbox(temp_mailbox);
+        
+        return locations;
+    }
+
+
+    /**
+     * @brief Delete a file on the storage service
+     *
+     * @param answer_mailbox: the answer mailbox to which the reply from the server should be sent
+     * @param location: the location to delete
+     * @param wait_for_answer: whether this call should
+     */
+    void CompoundStorageService::deleteFile(simgrid::s4u::Mailbox *answer_mailbox,
+                                    const std::shared_ptr<FileLocation> &location,
+                                    bool wait_for_answer) {
+        WRENCH_INFO("CSS::deleteFile(): Starting for file %s", location->getFile()->getID().c_str());
+
+        if (!answer_mailbox or !location) {
+            throw std::invalid_argument("CSS::deleteFile(): Invalid nullptr arguments");
+        }
+ 
+        if (location->isScratch()) {
+            throw std::invalid_argument("CSS::deleteFile(): Cannot be called on a SCRATCH location");
+        }
+
+
+        auto designated_locations = this->lookupFileLocation(location);
+        if ( designated_locations.empty() ) {
+            throw ExecutionException(std::make_shared<FileNotFound>(location));
+        }
+
+        this->traceInternalStorageUse(IOAction::DeleteStart, designated_locations);
+
+        // Send a message to the storage service's daemon
+        for (const auto& loc : designated_locations) {
+
+            WRENCH_INFO("CSS:deleteFile Issuing delete message to SSS %s", loc->getStorageService()->getName().c_str());
+
+            assertServiceIsUp(loc->getStorageService());
+
+            S4U_Mailbox::putMessage(loc->getStorageService()->mailbox,
+                                new StorageServiceFileDeleteRequestMessage(
+                                        answer_mailbox,
+                                        loc,
+                                        this->getMessagePayloadValue(StorageServiceMessagePayload::FILE_DELETE_REQUEST_MESSAGE_PAYLOAD)));
+
+            if (wait_for_answer) {
+
+                // Wait for a reply
+                std::unique_ptr<SimulationMessage> message = nullptr;
+
+                auto msg = S4U_Mailbox::getMessage<StorageServiceFileDeleteAnswerMessage>(answer_mailbox, this->network_timeout, "StorageService::deleteFile():");
+                // On failure, throw an exception
+                if (!msg->success) {
+                    throw ExecutionException(std::move(msg->failure_cause));
+                }
+            }
+        }
+
+        // Clean up local map
+        this->file_location_mapping.erase(location->getFile());
+
+        // Collect traces
+        wrench::AllocationTrace trace;
+        // trace.file_name = location->getFile()->getID();
+        trace.ts = S4U_Simulation::getClock();
+        trace.internal_locations = designated_locations;
+        trace.act = IOAction::DeleteEnd;
+        this->delete_traces[location->getFile()->getID()] = trace;
+        
+        this->traceInternalStorageUse(IOAction::DeleteEnd, designated_locations);
+
+        WRENCH_INFO("CSS::deleteFile Done for file %s", location->getFile()->getID().c_str());
     }
 
     /**
-     * @brief Handle (and intercept) a file delete request
+     * @brief Asks the storage service whether it holds a file
      *
-     * @param msg: The StorageServiceFileDeleteRequestMessage received by a CompoundStorageService
+     * @param answer_mailbox: the answer mailbox to which the reply from the server should be sent
+     * @param location: the location to lookup
      *
-     * @return true if this process should keep running
+     * @return true if the file is present, false otherwise
      */
-    bool CompoundStorageService::processFileDeleteRequest(StorageServiceFileDeleteRequestMessage *msg) {
-        auto designated_location = this->lookupFileLocation(msg->location);
-        if (!designated_location) {
-            WRENCH_WARN("processFileDeleteRequest: Unable to find file %s",
-                        msg->location->getFile()->getID().c_str());
-            try {
-                S4U_Mailbox::dputMessage(
-                        msg->answer_mailbox,
-                        new StorageServiceFileDeleteAnswerMessage(
-                                nullptr,
-                                this->getSharedPtr<CompoundStorageService>(),
-                                false,
-                                std::shared_ptr<FailureCause>(new FileNotFound(msg->location)),
-                                this->getMessagePayloadValue(
-                                        CompoundStorageServiceMessagePayload::FILE_DELETE_ANSWER_MESSAGE_PAYLOAD)));
-            } catch (wrench::ExecutionException &e) {}
+    bool CompoundStorageService::lookupFile(simgrid::s4u::Mailbox *answer_mailbox,
+                                    const std::shared_ptr<FileLocation> &location) {
+        WRENCH_INFO("CSS::lookupFile(): Lookup for file %s", location->getFile()->getID().c_str());
 
-            return true;
+        if (!answer_mailbox or !location) {
+            throw std::invalid_argument("CSS::lookupFile(): Invalid nullptr arguments");
         }
 
-        S4U_Mailbox::putMessage(
-                designated_location->getStorageService()->mailbox,
-                new StorageServiceFileDeleteRequestMessage(
-                        msg->answer_mailbox,
-                        designated_location,
-                        designated_location->getStorageService()->getMessagePayloadValue(
-                                StorageServiceMessagePayload::FILE_DELETE_REQUEST_MESSAGE_PAYLOAD)));
-
-        return true;
-    }
-
-    /**
-     * @brief Handle (and intercept) a file lookup request
-     *
-     * @param msg: The StorageServiceFileLookupRequestMessage received by a CompoundStorageService
-     *
-     * @return true if this process should keep running
-     */
-    bool CompoundStorageService::processFileLookupRequest(StorageServiceFileLookupRequestMessage *msg) {
-        auto designated_location = this->lookupFileLocation(msg->location);
-        if (!designated_location) {
-            WRENCH_WARN("processFileLookupRequest: Unable to find file %s", msg->location->getFile()->getID().c_str());
-            // Abort because we don't know the file (it should have been written or copied somewhere before the lookup happens)
-            try {
-                S4U_Mailbox::dputMessage(
-                        msg->answer_mailbox,
-                        new StorageServiceFileLookupAnswerMessage(
-                                nullptr, false,
-                                this->getMessagePayloadValue(
-                                        CompoundStorageServiceMessagePayload::FILE_LOOKUP_ANSWER_MESSAGE_PAYLOAD)));
-            } catch (wrench::ExecutionException &e) {}
-
-            return true;
+        auto file_parts = this->lookupFileLocation(location);
+        if (file_parts.empty()) {
+            WRENCH_WARN("File lookup failed because CSS doesn't know of file");
+            return false;
         }
 
-        // The file is known, we can forward the request to the underlying designated StorageService
-        S4U_Mailbox::putMessage(
-                designated_location->getStorageService()->mailbox,
+        bool available = true;
+
+        // Send a message to the storage service's daemon
+        for (const auto& loc : file_parts) {
+        
+            assertServiceIsUp(loc->getStorageService());
+
+            S4U_Mailbox::putMessage(loc->getStorageService()->mailbox,
                 new StorageServiceFileLookupRequestMessage(
-                        msg->answer_mailbox,
-                        FileLocation::LOCATION(
-                                designated_location->getStorageService(),
-                                designated_location->getPath(),
-                                designated_location->getFile()),
-                        designated_location->getStorageService()->getMessagePayloadValue(
+                        answer_mailbox,
+                        location,
+                        this->getMessagePayloadValue(
                                 StorageServiceMessagePayload::FILE_LOOKUP_REQUEST_MESSAGE_PAYLOAD)));
 
-        return true;
+            // Wait for a reply
+            auto msg = S4U_Mailbox::getMessage<StorageServiceFileLookupAnswerMessage>(answer_mailbox, this->network_timeout, "StorageService::lookupFile():");
+            available &= msg->file_is_available;
+        }
+
+        return available;
     }
 
-    /**
-     * @brief Handle (and intercept) a file copy request
-     *
-     * @param msg: The StorageServiceFileCopyRequestMessage received by a CompoundStorageService
-     *
-     * @return true if this process should keep running
+    void CompoundStorageService::copyFile(const std::shared_ptr<FileLocation> &src_location,
+                                          const std::shared_ptr<FileLocation> &dst_location) {
+
+        WRENCH_INFO("CSS::copyFile(): Copy %s between %s and %s", 
+                    src_location->getFile()->getID().c_str(),
+                    src_location->getStorageService()->getName().c_str(),
+                    dst_location->getStorageService()->getName().c_str());
+
+        // Check if source file is on a CSS and whether or not it is stripped across many locations
+        bool src_is_css = false;
+        if (std::dynamic_pointer_cast<CompoundStorageService>(src_location->getStorageService())) {
+            src_is_css = true;
+        }
+
+        // Check if destination file is on a CSS and whether or not it is stripped across many locations
+        bool dst_is_css = false;
+        if (std::dynamic_pointer_cast<CompoundStorageService>(dst_location->getStorageService())) {
+            dst_is_css = true;
+        }
+
+        if (src_is_css and !dst_is_css) {
+            WRENCH_INFO("CSS::copyFile(): src_location is on a CSS");
+            auto src_css = std::dynamic_pointer_cast<CompoundStorageService>(src_location->getStorageService());
+            src_css->copyFileIamSource(src_location, dst_location);
+
+        } else if (!src_is_css and dst_is_css) {
+            WRENCH_INFO("CSS::copyFile(): dst_location is on a CSS");
+            auto dst_css = std::dynamic_pointer_cast<CompoundStorageService>(dst_location->getStorageService());
+            dst_css->copyFileIamDestination(src_location, dst_location);
+
+        } else if (src_is_css and dst_is_css) {
+            // Case where both src and dst are CSS
+            WRENCH_INFO("CSS::copyFile(): src_location AND dst_location are on a CSS");
+            throw std::invalid_argument("CompoundStorageService::copyFile() copy from CSS to CSS not yet handled");
+
+        } else {
+            WRENCH_WARN("CSS::copyFile(): called but neither src or dst is a CSS");
+            throw std::invalid_argument("CompoundStorageService::copyFile() called but neither src or dst is a CSS");
+        }
+    }
+        
+    /** 
+     * @brief Copy file from css to a simple storage service (file might be stripped within the CSS, but should be
+     *        reassembled on the SSS)
+     * 
      */
-    bool CompoundStorageService::processFileCopyRequest(StorageServiceFileCopyRequestMessage *msg) {
+    void CompoundStorageService::copyFileIamSource(const std::shared_ptr<FileLocation> &src_location,
+                                                   const std::shared_ptr<FileLocation> &dst_location) {
+        WRENCH_INFO("CSS::copyFileIamSource()");        
 
-        // If source location references a CSS, it must already be known to the CSS
-        auto final_src = msg->src;
-        if (std::dynamic_pointer_cast<CompoundStorageService>(msg->src->getStorageService())) {
-            final_src = this->lookupFileLocation(msg->src->getFile());
-        }
-        // If destination location references a CSS, it must already exist OR we must be able to allocate it
-        auto final_dst = msg->dst;
-        if (std::dynamic_pointer_cast<CompoundStorageService>(msg->dst->getStorageService())) {
-            final_dst = this->lookupOrDesignateStorageService(msg->dst);
-        }
+        std::vector<std::shared_ptr<FileLocation>> src_parts = {};
+        std::vector<std::shared_ptr<FileLocation>> dst_parts = {};
 
-        //        std::cerr << "FINAL DST = " << (final_dst == nullptr) << "\n";
-
-        // Error case - src
-        if (!final_src) {
-            WRENCH_WARN("processFileCopyRequest: Source %s is a CompoundStorageService and file doesn't exist yet.",
-                        msg->src->getStorageService()->getName().c_str());
-            try {
-                std::string error = "CompoundStorageService can't be the source of a file copy if the file has"
-                                    " not already been written or copied to it.";
-
-                S4U_Mailbox::putMessage(
-                        msg->answer_mailbox,
-                        new StorageServiceFileCopyAnswerMessage(
-                                msg->src,
-                                msg->dst,
-                                false,
-                                std::shared_ptr<FailureCause>(new NotAllowed(
-                                        this->getSharedPtr<CompoundStorageService>(),
-                                        error)),
-                                this->getMessagePayloadValue(
-                                        CompoundStorageServiceMessagePayload::FILE_COPY_ANSWER_MESSAGE_PAYLOAD)));
-            } catch (ExecutionException &e) {}
-
-            return true;
+        // Find source file or parts of source file from within internal sss of the CSS (source file must be known)
+        src_parts = this->lookupFileLocation(src_location);
+        if (src_parts.empty()) {
+            throw ExecutionException(std::make_shared<FileNotFound>(src_location));
         }
 
-        // Error case - dst
-        if (!final_dst) {
-            WRENCH_WARN("processFileCopyRequest: Destination file %s not found or not enough space left",
-                        msg->dst->getFile()->getID().c_str());
+        WRENCH_INFO("CSS::copyFileIamSource(): Source file has %zu known part(s)", src_parts.size());
+        if (src_parts.size() > 1) {
+            for (const auto& src_part : src_parts) {
+                dst_parts.push_back(
+                    FileLocation::LOCATION(dst_location->getStorageService(), dst_location->getPath(), src_part->getFile())
+                );
+            }
+        } else {
+            dst_parts.push_back(dst_location);  // no stripping, dst location doesn't have to change
+        }
 
-            std::shared_ptr<FailureCause> failure_cause;
-            if (!this->isStorageSelectionUserProvided) {
-                std::string err = "CompoundStorageService doesn't know dst file and can't allocate it because no storage_selection callback was provided";
-                failure_cause = std::make_shared<NotAllowed>(
-                        this->getSharedPtr<CompoundStorageService>(),
-                        err);
+        // Now run the copy(ies) between the source(s) and the destination(s)
+        auto copy_idx = 0;
+        int total_parts = src_parts.size(); // = dst_parts.size() 
+
+        std::vector<simgrid::s4u::Mailbox*> tmp_mailboxes = {};
+
+        while(copy_idx < total_parts) {
+            WRENCH_INFO("CSS::copyFileIamSource(): Running StorageService::copyFile for part %i", copy_idx);
+
+            auto tmp_mailbox = S4U_Mailbox::getTemporaryMailbox(); 
+            tmp_mailboxes.push_back(tmp_mailbox);
+
+            assertServiceIsUp(src_parts[copy_idx]->getStorageService());
+            assertServiceIsUp(dst_parts[copy_idx]->getStorageService());
+
+            auto file = src_parts[copy_idx]->getFile();
+            bool src_is_bufferized = src_parts[copy_idx]->getStorageService()->isBufferized();
+            bool src_is_non_bufferized = not src_is_bufferized;
+            bool dst_is_bufferized = dst_parts[copy_idx]->getStorageService()->isBufferized();
+            bool dst_is_non_bufferized = not dst_is_bufferized;
+
+            simgrid::s4u::Mailbox *mailbox_to_contact;
+            if (dst_is_non_bufferized) {
+                mailbox_to_contact = dst_parts[copy_idx]->getStorageService()->mailbox;
+            } else if (src_is_non_bufferized) {
+                mailbox_to_contact = src_parts[copy_idx]->getStorageService()->mailbox;
             } else {
-                failure_cause = std::make_shared<StorageServiceNotEnoughSpace>(
-                        msg->dst->getFile(),
-                        this->getSharedPtr<CompoundStorageService>());
+                mailbox_to_contact = dst_parts[copy_idx]->getStorageService()->mailbox;
             }
 
-            try {
-                S4U_Mailbox::putMessage(
-                        msg->answer_mailbox,
-                        new StorageServiceFileCopyAnswerMessage(
-                                msg->src,
-                                msg->dst,
-                                false,
-                                failure_cause,
-                                this->getMessagePayloadValue(
-                                        CompoundStorageServiceMessagePayload::FILE_COPY_ANSWER_MESSAGE_PAYLOAD)));
-            } catch (ExecutionException &e) {}
+            this->simulation->getOutput().addTimestampFileCopyStart(Simulation::getCurrentSimulatedDate(), file,
+                                                                                                src_parts[copy_idx],
+                                                                                                dst_parts[copy_idx]);
+            S4U_Mailbox::dputMessage(
+                    mailbox_to_contact,
+                    new StorageServiceFileCopyRequestMessage(
+                            tmp_mailbox,
+                            src_parts[copy_idx],
+                            dst_parts[copy_idx],
+                            dst_parts[copy_idx]->getStorageService()->getMessagePayloadValue(
+                                    StorageServiceMessagePayload::FILE_COPY_REQUEST_MESSAGE_PAYLOAD)));
 
-            return true;
+            //StorageService::copyFile(src_parts[copy_idx], dst_parts[copy_idx]);
+            copy_idx++;
         }
 
-        // Depending on whether we updated source or destination, we now need to find
-        // to which to forward the message
-        bool src_is_bufferized = final_src->getStorageService()->isBufferized();
-        bool dst_is_bufferized = final_dst->getStorageService()->isBufferized();
+        WRENCH_INFO("CSS::copyFileIamSource(): Copy/ies started");
 
-        simgrid::s4u::Mailbox *mailbox_to_contact;
-        if (!dst_is_bufferized) {
-            mailbox_to_contact = final_dst->getStorageService()->mailbox;
-        } else if (!src_is_bufferized) {
-            mailbox_to_contact = final_src->getStorageService()->mailbox;
+        // Wait for all replies
+        for (const auto& mailbox : tmp_mailboxes) {
+
+            auto msg = S4U_Mailbox::getMessage<StorageServiceFileCopyAnswerMessage>(mailbox);
+
+            if (msg->failure_cause) {
+                WRENCH_DEBUG("%s", msg->failure_cause->toString().c_str());
+                throw ExecutionException(std::move(msg->failure_cause));
+            }
+
+            S4U_Mailbox::retireTemporaryMailbox(mailbox);
+
+        }
+
+        WRENCH_INFO("CSS::copyFileIamSource(): Copy/ies started (answers received)");
+
+        // Cleanup
+        if(total_parts > 1) {
+            // once all the copies are made, we need to delete parts on destination and merge into a single file
+            for (const auto& part : dst_parts) {
+                dst_location->getStorageService()->deleteFileAtLocation(part);
+            }
+            dst_location->getStorageService()->createFileAtLocation(FileLocation::LOCATION(
+                dst_location->getStorageService(), dst_location->getPath(), dst_location->getFile()));
+        }
+
+        // Collect traces
+        wrench::AllocationTrace trace;
+        // trace.file_name = src_location->getFile()->getID();
+        trace.ts = S4U_Simulation::getClock();
+        trace.internal_locations = src_parts;
+        trace.act = IOAction::CopyToEnd;
+        this->copy_traces[src_location->getFile()->getID()] = trace;
+
+        WRENCH_INFO("CSS::copyFileIamSource(): Done (cleanup + tracing)");
+    }
+
+    /** 
+     * @brief Copy file from a SimpleStorageService to a CSS. Src file cannot be stripped, but copy might
+     *          result in stripped file on CSS.
+     * 
+     */
+    void CompoundStorageService::copyFileIamDestination(const std::shared_ptr<FileLocation> &src_location,
+                                                        const std::shared_ptr<FileLocation> &dst_location) {
+        
+        WRENCH_INFO("CSS::copyFileIamDestination()");
+
+        // this->traceInternalStorageUse(IOAction::CopyToStart);
+
+        std::vector<std::shared_ptr<FileLocation>> src_parts = {};
+        std::vector<std::shared_ptr<FileLocation>> dst_parts = {};
+
+        // Find one or many SSS location(s) for the destination file (depending on whether the original file needs stripping or not)
+        dst_parts = this->lookupOrDesignateStorageService(dst_location);
+        if (dst_parts.empty()) {
+            throw ExecutionException(std::make_shared<StorageServiceNotEnoughSpace>(dst_location->getFile(), this->getSharedPtr<CompoundStorageService>()));
+        }
+
+        this->traceInternalStorageUse(IOAction::CopyToStart, dst_parts);
+        WRENCH_INFO("CSS::copyFileIamDestination(): Destination file will be written as %zu file part(s)", dst_parts.size());
+        if (dst_parts.size() > 1) {
+            for (const auto& dst_part : dst_parts) {
+                auto part_size = dst_part->getFile()->getSize();
+                dst_part->getFile()->setSize(0);                // make our datafile act as a reference / link
+                StorageService::createFileAtLocation(           // create link on source storage service
+                    FileLocation::LOCATION(
+                        src_location->getStorageService(), 
+                        src_location->getPath(), 
+                        dst_part->getFile())
+                );
+                // Prepare for copy once again
+                dst_part->getFile()->setSize(part_size);
+                src_parts.push_back(
+                    FileLocation::LOCATION(src_location->getStorageService(), src_location->getPath(), dst_part->getFile())
+                );
+            }
+            WRENCH_INFO("CSS::copyFileIamDestination(): %zu parts created from source file", src_parts.size());
         } else {
-            mailbox_to_contact = final_dst->getStorageService()->mailbox;
+            src_parts.push_back(src_location);  // no stripping, src location doesn't have to change
         }
 
-        S4U_Mailbox::putMessage(
-                mailbox_to_contact,
-                new StorageServiceFileCopyRequestMessage(
-                        msg->answer_mailbox,
-                        final_src,
-                        final_dst,
-                        final_dst->getStorageService()->getMessagePayloadValue(
-                                StorageServiceMessagePayload::FILE_COPY_REQUEST_MESSAGE_PAYLOAD)));
+        // Now run the copy(ies) between the source(s) and the destination(s)
+        auto copy_idx = 0;
+        int total_parts = src_parts.size(); // = dst_parts.size() 
 
-        return true;
+        std::vector<simgrid::s4u::Mailbox*> tmp_mailboxes = {};
+
+        while(copy_idx < total_parts) {
+            WRENCH_INFO("CSS::copyFileIamDestination(): Running StorageService::copyFile for part %i", copy_idx);
+            WRENCH_INFO("CSS::copyFileIamDestination(): Source = %s with size %f at path %s on  %s%s", 
+                         src_parts[copy_idx]->getFile()->getID().c_str(),
+                         src_parts[copy_idx]->getFile()->getSize(),
+                         src_parts[copy_idx]->getPath().c_str(),
+                         src_parts[copy_idx]->getStorageService()->getHostname().c_str(),
+                         src_parts[copy_idx]->getStorageService()->getBaseRootPath().c_str());
+            WRENCH_INFO("CSS::copyFileIamDestination(): Dest = %s with size %f at path %s on  %s%s", 
+                         dst_parts[copy_idx]->getFile()->getID().c_str(),
+                         dst_parts[copy_idx]->getFile()->getSize(),
+                         dst_parts[copy_idx]->getPath().c_str(),
+                         dst_parts[copy_idx]->getStorageService()->getHostname().c_str(),
+                         dst_parts[copy_idx]->getStorageService()->getBaseRootPath().c_str());
+
+            // Useful ?
+            assertServiceIsUp(src_parts[copy_idx]->getStorageService());
+            assertServiceIsUp(dst_parts[copy_idx]->getStorageService());
+
+            auto file = src_parts[copy_idx]->getFile();
+            bool src_is_bufferized = src_parts[copy_idx]->getStorageService()->isBufferized();
+            bool src_is_non_bufferized = not src_is_bufferized;
+            bool dst_is_bufferized = dst_parts[copy_idx]->getStorageService()->isBufferized();
+            bool dst_is_non_bufferized = not dst_is_bufferized;
+
+            simgrid::s4u::Mailbox *mailbox_to_contact;
+            if (dst_is_non_bufferized) {
+                mailbox_to_contact = dst_parts[copy_idx]->getStorageService()->mailbox;
+            } else if (src_is_non_bufferized) {
+                mailbox_to_contact = src_parts[copy_idx]->getStorageService()->mailbox;
+            } else {
+                mailbox_to_contact = dst_parts[copy_idx]->getStorageService()->mailbox;
+            }
+
+            // Send a message to the daemon of the dst service
+            auto tmp_mailbox = S4U_Mailbox::getTemporaryMailbox();
+            tmp_mailboxes.push_back(tmp_mailbox);
+
+            this->simulation->getOutput().addTimestampFileCopyStart(Simulation::getCurrentSimulatedDate(), file,
+                                                                                                src_parts[copy_idx],
+                                                                                                dst_parts[copy_idx]);
+            
+            // That's quite dirty, but : space is reserved during the call to lookupOrDesignateFileLocation, so that
+            // we keep track of future space usage on various storage nodes while allocating multiple chunks of a given
+            // file. So right before we actually start the copy, we unreserve space.
+            dst_parts[copy_idx]->getStorageService()->unreserveSpace(dst_parts[copy_idx]);
+            // TODO : Replace with iputMessage()
+            S4U_Mailbox::dputMessage(
+                    mailbox_to_contact,
+                    new StorageServiceFileCopyRequestMessage(
+                            tmp_mailbox,
+                            src_parts[copy_idx],
+                            dst_parts[copy_idx],
+                            dst_parts[copy_idx]->getStorageService()->getMessagePayloadValue(
+                                    StorageServiceMessagePayload::FILE_COPY_REQUEST_MESSAGE_PAYLOAD)));
+
+            copy_idx++;
+
+        }
+        
+        WRENCH_INFO("CSS::copyFileIamDestination(): Copy/ies started");
+
+        // Wait for all replies
+        for (const auto& mailbox : tmp_mailboxes) {
+
+            auto msg = S4U_Mailbox::getMessage<StorageServiceFileCopyAnswerMessage>(mailbox);
+
+            if (msg->failure_cause) {
+                WRENCH_DEBUG("%s", msg->failure_cause->toString().c_str());
+                throw ExecutionException(std::move(msg->failure_cause));
+            }
+
+            S4U_Mailbox::retireTemporaryMailbox(mailbox);
+
+        }
+
+        WRENCH_INFO("CSS::copyFileIamDestination(): Copy/ies started (answers received)");
+
+        // Once copy is done, remove links (only if source file was stripped)
+        if (total_parts > 1) {
+            for (const auto& src_part : src_parts) {
+                WRENCH_INFO("CSS::copyFileIamDestination(): ");
+                auto part_size = src_part->getFile()->getSize();
+                src_part->getFile()->setSize(0); // make our datafile a link once again
+                WRENCH_INFO("CSS::copyFileIamDestination(): Deleting part %s", src_part->getFile()->getID().c_str());
+                StorageService::deleteFileAtLocation(src_part);
+                src_part->getFile()->setSize(part_size);
+            }
+        }
+
+        WRENCH_INFO("CSS::copyFileIamDestination(): Source parts deleted (if needed)");
+
+        // Collect traces
+        wrench::AllocationTrace trace;
+        // trace.file_name = dst_location->getFile()->getID();
+        trace.act = IOAction::WriteEnd;
+        trace.ts = S4U_Simulation::getClock();
+        trace.internal_locations = dst_parts;
+        this->copy_traces[dst_location->getFile()->getID()] = trace;
+
+        this->traceInternalStorageUse(IOAction::CopyToEnd, dst_parts);
+
+        WRENCH_INFO("CSS::copyFileIamDestination(): Done (cleanup + tracing)");
     }
 
-    /**
-     * @brief Handle (and intercept) a file write request. 
-     *        Note: Currently it's not reachable, because we also override a writeFile,
-     *        but intercepting the write message would probably be better.
-     *
-     * @param msg: The StorageServiceFileWriteRequestMessage received by a CompoundStorageService
-     * @return true if this process should keep running
-     */
-    bool CompoundStorageService::processFileWriteRequest(StorageServiceFileWriteRequestMessage *msg) {
-        auto designated_location = this->lookupOrDesignateStorageService(msg->location);
-        if (!designated_location) {
-            WRENCH_WARN("processFileWriteRequest: Destination file %s not found or not enough space left",
-                        msg->location->getFile()->getID().c_str());
-            try {
-                S4U_Mailbox::dputMessage(
-                        msg->answer_mailbox,
-                        new StorageServiceFileWriteAnswerMessage(
-                                msg->location,
-                                false,
-                                std::shared_ptr<FailureCause>(new FileNotFound(msg->location)),
-                                {},
-                                0,
-                                this->getMessagePayloadValue(
-                                        CompoundStorageServiceMessagePayload::FILE_WRITE_ANSWER_MESSAGE_PAYLOAD)));
-            } catch (wrench::ExecutionException &e) {}
 
-            return true;
+    /**
+     * @brief Synchronously write a file to the storage service
+     *
+     * @param answer_mailbox: the mailbox on which to expect the answer
+     * @param location: the location
+     * @param wait_for_answer: whether to wait for the answer
+     *
+     * @throw ExecutionException
+     */
+    void CompoundStorageService::writeFile(simgrid::s4u::Mailbox *answer_mailbox,
+                                   const std::shared_ptr<FileLocation> &location,
+                                   bool wait_for_answer) {
+
+        WRENCH_INFO("CSS::writeFile(): Writing file %s", location->getFile()->getID().c_str());
+        //this->traceInternalStorageUse(IOAction::WriteStart);
+
+        if (location == nullptr) {
+            throw std::invalid_argument("CSS::writeFile(): Invalid arguments");
         }
 
-        // The file is known or added to the local mapping, we can forward the request to the underlying designated StorageService
-        S4U_Mailbox::putMessage(
-                designated_location->getStorageService()->mailbox,
+        this->assertServiceIsUp();
+
+        // Find the file, or allocate file/parts of file onto known SSS
+        auto designated_locations = this->lookupOrDesignateStorageService(location);
+
+        if (designated_locations.empty()) {
+            throw ExecutionException(std::make_shared<StorageServiceNotEnoughSpace>(location->getFile(), this->getSharedPtr<CompoundStorageService>()));
+        }
+        std::vector<std::unique_ptr<wrench::StorageServiceFileWriteAnswerMessage>> messages = {};
+        std::vector<std::pair<simgrid::s4u::Mailbox*, std::unique_ptr<wrench::StorageServiceFileWriteAnswerMessage>>> mailbox_msg_pairs = {};
+
+        this->traceInternalStorageUse(IOAction::WriteStart, designated_locations);
+        WRENCH_INFO("CSS::writeFile(): Destination file %s will have %zu", 
+                     location->getFile()->getID().c_str(), designated_locations.size());
+
+        // Contact every SimpleStorageService that we want to use, and request a FileWrite
+        auto request_count = 0;
+        for (auto& dloc : designated_locations) {
+            auto tmp_mailbox = S4U_Mailbox::getTemporaryMailbox(); 
+            mailbox_msg_pairs.push_back(std::make_pair(tmp_mailbox, nullptr));
+
+            WRENCH_INFO("CSS:writeFile(): Sending write request for part %d to %s", request_count, dloc->getStorageService()->getName().c_str());
+
+            // That's quite dirty, but : space is reserved during the call to lookupOrDesignateFileLocation, so that
+            // we keep track of future space usage on various storage nodes while allocating multiple chunks of a given
+            // file. So right before we actually start the copy, we unreserve space.
+            dloc->getStorageService()->unreserveSpace(dloc);
+            // TODO : Replace with iputMessage()
+            S4U_Mailbox::dputMessage(
+                dloc->getStorageService()->mailbox,
                 new StorageServiceFileWriteRequestMessage(
-                        msg->answer_mailbox,
-                        msg->requesting_host,
-                        designated_location,
-                        this->getMessagePayloadValue(
-                                StorageServiceMessagePayload::FILE_WRITE_REQUEST_MESSAGE_PAYLOAD)));
+                    tmp_mailbox,
+                    simgrid::s4u::this_actor::get_host(),
+                    dloc,
+                    this->getMessagePayloadValue(
+                        CompoundStorageServiceMessagePayload::FILE_WRITE_REQUEST_MESSAGE_PAYLOAD))); 
+            request_count++;           
+        }
 
-        return true;
+        for(auto& mailbox_pair : mailbox_msg_pairs) {
+            // Wait for answer to current reqeust
+            auto msg = S4U_Mailbox::getMessage<StorageServiceFileWriteAnswerMessage>(mailbox_pair.first, this->network_timeout, "CSS::writeFile(): ");
+            if (not msg->success) 
+                throw ExecutionException(msg->failure_cause); 
+
+            mailbox_pair.second = std::move(msg);
+        }
+
+        WRENCH_INFO("CSS::writeFile(): All requests sent and validated");
+
+        for (const auto& mailbx_msg : mailbox_msg_pairs) {
+
+            // Update buffer size according to which storage service actually answered.
+            auto buffer_size = mailbx_msg.second->buffer_size;
+
+            if (buffer_size >= 1) {
+
+                auto file = location->getFile();
+                for (auto const &dwmb: mailbx_msg.second->data_write_mailboxes_and_bytes) {
+                    // Bufferized
+                    double remaining = dwmb.second;
+                    while (remaining - buffer_size > DBL_EPSILON) {
+                        S4U_Mailbox::dputMessage(dwmb.first,
+                                                new StorageServiceFileContentChunkMessage(
+                                                        file, buffer_size, false));
+                        remaining -= buffer_size;
+                    }
+                    S4U_Mailbox::dputMessage(dwmb.first, new StorageServiceFileContentChunkMessage(
+                                                                file, remaining, true));
+
+                }
+            }
+        }
+
+        for (const auto& mailbx_msg : mailbox_msg_pairs) {
+            WRENCH_INFO("CSS::writeFile(): Waiting for final ack");
+            S4U_Mailbox::getMessage<StorageServiceAckMessage>(mailbx_msg.first, "CSS::writeFile(): ");
+            S4U_Mailbox::retireTemporaryMailbox(mailbx_msg.first);
+        }
+
+        WRENCH_INFO("CSS::writeFile(): All writes done and ack");
+        this->traceInternalStorageUse(IOAction::WriteEnd, designated_locations);
+
+        // Collect traces
+        wrench::AllocationTrace trace;
+        trace.act = IOAction::WriteEnd;
+        trace.ts = S4U_Simulation::getClock();
+        trace.internal_locations = designated_locations;
+        this->write_traces[location->getFile()->getID()] = trace;
     }
 
     /**
-     * @brief Handle (and intercept) a file read request. 
+     * @brief Read a file from the storage service
      *
-     * @param msg: The StorageServiceFileReadRequestMessage received by a CompoundStorageService
-     * @return true if this process should keep running
+     * @param answer_mailbox: the mailbox on which to expect the answer
+     * @param location: the location
+     * @param num_bytes: the number of bytes to read
+     * @param wait_for_answer: whether to wait for the answer
      */
-    bool CompoundStorageService::processFileReadRequest(StorageServiceFileReadRequestMessage *msg) {
-        auto designated_location = this->lookupFileLocation(msg->location);
-        if (!designated_location) {
-            WRENCH_WARN("processFileReadRequest: file %s not found", msg->location->getFile()->getID().c_str());
-            try {
-                S4U_Mailbox::dputMessage(
-                        msg->answer_mailbox,
-                        new StorageServiceFileReadAnswerMessage(
-                                msg->location,
-                                false,
-                                std::shared_ptr<FailureCause>(new FileNotFound(msg->location)),
-                                nullptr,
-                                0,
-                                1,
-                                this->getMessagePayloadValue(
-                                        CompoundStorageServiceMessagePayload::FILE_READ_ANSWER_MESSAGE_PAYLOAD)));
-            } catch (wrench::ExecutionException &e) {}
+    void CompoundStorageService::readFile(simgrid::s4u::Mailbox *answer_mailbox,
+                                  const std::shared_ptr<FileLocation> &location,
+                                  double num_bytes,
+                                  bool wait_for_answer) {
+        WRENCH_INFO("CSS::readFile(): Reading file %s", location->getFile()->getID().c_str());
 
-            return true;
+        if (!answer_mailbox or !location or (num_bytes < 0.0)) {
+            throw std::invalid_argument("StorageService::readFile(): Invalid nullptr/0 arguments");
         }
 
-        WRENCH_DEBUG("processFileReadRequest: Going to read file %s on storage service %s, at path %s",
-                     designated_location->getFile()->getID().c_str(),
-                     designated_location->getStorageService()->getName().c_str(),
-                     designated_location->getPath().c_str());
+        assertServiceIsUp(this->shared_from_this());
 
-        S4U_Mailbox::putMessage(
-                designated_location->getStorageService()->mailbox,
+        auto designated_locations = this->lookupFileLocation(location);
+        if (designated_locations.empty()) {
+            throw ExecutionException(std::make_shared<FileNotFound>(location));
+        }
+        
+        // Contact every SSS
+        auto left_to_receive = designated_locations.size();
+        std::vector<std::pair<simgrid::s4u::Mailbox*, std::unique_ptr<wrench::StorageServiceFileReadAnswerMessage>>> mailbox_msg_pairs = {};
+
+        for (const auto& dloc : designated_locations) {
+            WRENCH_INFO("CSS::readFile(): Sending read file request for file %s at path %s, to storage service %s",
+                     dloc->getFile()->getID().c_str(),
+                     dloc->getPath().c_str(),
+                     dloc->getStorageService()->getName().c_str());
+
+            auto tmp_mailbox = S4U_Mailbox::getTemporaryMailbox(); 
+            mailbox_msg_pairs.push_back(std::make_pair(tmp_mailbox, nullptr));
+                    
+            // REPLACE WITH iputMessage()?
+            S4U_Mailbox::dputMessage(
+                dloc->getStorageService()->mailbox,
                 new StorageServiceFileReadRequestMessage(
-                        msg->answer_mailbox,
-                        msg->requesting_host,
-                        designated_location,
-                        msg->num_bytes_to_read,
-                        designated_location->getStorageService()->getMessagePayloadValue(
-                                StorageServiceMessagePayload::FILE_READ_REQUEST_MESSAGE_PAYLOAD)));
+                        tmp_mailbox,
+                        simgrid::s4u::this_actor::get_host(),
+                        dloc,
+                        dloc->getFile()->getSize(),
+                        dloc->getStorageService()->getMessagePayloadValue(
+                                CompoundStorageServiceMessagePayload::FILE_READ_REQUEST_MESSAGE_PAYLOAD)));
 
-        return true;
+        }
+
+        for (auto& mailbox_pair : mailbox_msg_pairs) {
+            // Wait for answer to current reqeust
+            auto msg = S4U_Mailbox::getMessage<StorageServiceFileReadAnswerMessage>(mailbox_pair.first, this->network_timeout, "CSS::readFile(): ");
+            if (not msg->success) 
+                throw ExecutionException(msg->failure_cause); 
+
+            mailbox_pair.second = std::move(msg);
+        }
+
+        WRENCH_INFO("CSS::readFile(): All requests sent and validated");
+
+        for (const auto& mailbx_msg : mailbox_msg_pairs) {
+
+            if (mailbx_msg.second->buffer_size < 1) {
+                // Non-Bufferized
+                // Just wait for the final ack (no timeout!)
+                S4U_Mailbox::getMessage<StorageServiceAckMessage>(mailbx_msg.first, "CSS::readFile(): ");
+            } else {
+                unsigned long number_of_sources = mailbx_msg.second->number_of_sources;
+
+                // Otherwise, retrieve the file chunks until the last one is received
+                // Noting that we have multiple sources
+                unsigned long num_final_chunks_received = 0;
+                while (true) {
+                    std::shared_ptr<StorageServiceFileContentChunkMessage> file_content_chunk_msg = nullptr;
+                    try {
+                        file_content_chunk_msg = S4U_Mailbox::getMessage<StorageServiceFileContentChunkMessage>(mailbx_msg.second->mailbox_to_receive_the_file_content, "StorageService::readFile(): Received an");
+                    } catch (...) {
+                        S4U_Mailbox::retireTemporaryMailbox(mailbx_msg.second->mailbox_to_receive_the_file_content);
+                        throw;
+                    }
+                    if (file_content_chunk_msg->last_chunk) {
+                        num_final_chunks_received++;
+                        if (num_final_chunks_received == mailbx_msg.second->number_of_sources) {
+                            break;
+                        }
+                    }
+                }
+
+                S4U_Mailbox::retireTemporaryMailbox(mailbx_msg.second->mailbox_to_receive_the_file_content);
+
+                //Waiting for all the final acks
+                for (unsigned long source = 0; source < number_of_sources; source++) {
+                    S4U_Mailbox::getMessage<StorageServiceAckMessage>(mailbx_msg.first, this->network_timeout, "StorageService::readFile(): Received an");
+                }
+
+            }
+
+            S4U_Mailbox::retireTemporaryMailbox(mailbx_msg.first);
+        }
+            
+        WRENCH_INFO("CSS::readFile(): All read done and ack");
+
+        // Collect traces
+        wrench::AllocationTrace trace;
+        // trace.file_name = location->getFile()->getID();
+        trace.ts = S4U_Simulation::getClock();
+        trace.act = IOAction::ReadEnd;
+        trace.internal_locations = designated_locations;
+        // this->read_traces[location->getFile()->getID()] = trace;
     }
-
 
     /**
      * @brief Get the load (number of concurrent reads) on the storage service
@@ -599,8 +1103,8 @@ namespace wrench {
      * @return the load on the service (currently throws)
      */
     double CompoundStorageService::getLoad() {
-        WRENCH_WARN("CompoundStorageService::getLoad Not implemented");
-        throw std::logic_error("CompoundStorageService::getLoad(): Not implemented. "
+        WRENCH_WARN("CSS::getLoad(): Not implemented");
+        throw std::logic_error("CSS::getLoad(): Not implemented. "
                                "Call getLoad() on an underlying storage service instead");
     }
 
@@ -614,9 +1118,10 @@ namespace wrench {
     double CompoundStorageService::getTotalSpace() {
         //        WRENCH_INFO("CompoundStorageService::getTotalSpace");
         double free_space = 0.0;
-        for (const auto &service: this->storage_services) {
-            auto service_name = service->getName();
-            free_space += service->getTotalSpace();
+        for (const auto &storage_server: this->storage_services) {
+            for (const auto &service : storage_server.second) {
+                free_space += service->getTotalSpace();
+            }
         }
         return free_space;
     }
@@ -633,11 +1138,13 @@ namespace wrench {
      *
      */
     double CompoundStorageService::getTotalFreeSpaceAtPath(const std::string &path) {
-        WRENCH_DEBUG("CompoundStorageService::getFreeSpace Forwarding request to internal services");
+        WRENCH_INFO("CSS::getFreeSpace Forwarding request to internal services");
 
         double free_space = 0.0;
-        for (const auto &service: this->storage_services) {
-            free_space += service->getTotalFreeSpaceAtPath(path);
+        for (const auto &storage_server: this->storage_services) {
+            for (const auto &service : storage_server.second) {
+                free_space += service->getTotalFreeSpaceAtPath(path);
+            }
         }
         return free_space;
     }
@@ -648,8 +1155,8 @@ namespace wrench {
      *  @throw std::logic_error
      */
     void CompoundStorageService::setIsScratch(bool is_scratch) {
-        WRENCH_WARN("CompoundStorageService::setScratch Forbidden because CompoundStorageService doesn't manage any storage resources itself");
-        throw std::logic_error("CompoundStorageService can't be setup as a scratch space, it is only an abstraction layer.");
+        WRENCH_WARN("CSS::setScratch Forbidden because CompoundStorageService doesn't manage any storage resources itself");
+        throw std::logic_error("CSS: can't be setup as a scratch space, it is only an abstraction layer.");
     }
 
     /**
@@ -657,8 +1164,8 @@ namespace wrench {
      * 
      * @return The set of known StorageServices.
     */
-    std::set<std::shared_ptr<StorageService>> &CompoundStorageService::getAllServices() {
-        WRENCH_DEBUG("CompoundStorageService::getAllServices");
+    std::map<std::string, std::vector<std::shared_ptr<wrench::StorageService>>> &CompoundStorageService::getAllServices() {
+        WRENCH_INFO("CSS::getAllServices");
         return this->storage_services;
     }
 
@@ -670,25 +1177,23 @@ namespace wrench {
      * @return a date in seconds, or -1 if the file is not found
      */
     double CompoundStorageService::getFileLastWriteDate(const std::shared_ptr<FileLocation> &location) {
+        
         if (location == nullptr) {
-            throw std::invalid_argument("CompoundStorageService::getFileLastWriteDate(): Invalid nullptr argument");
+            throw std::invalid_argument("CSS::getFileLastWriteDate(): Invalid nullptr argument");
         }
-        if (!this->hasFile(location)) {
-            throw std::invalid_argument("CompoundStorageService::getFileLastWriteDate(): File not known to the CompoundStorageService. Unable to forward to underlying StorageService");
-        }
-        auto file = location->getFile();
-
-        if ((this->file_location_mapping.find(file) == this->file_location_mapping.end()) or
-            (this->file_location_mapping[file]->getPath() != FileLocation::sanitizePath(location->getPath()))) {
-            return -1;
+       
+        auto designated_locations = this->lookupFileLocation(location);
+        if (designated_locations.empty()) {
+            throw std::invalid_argument("CSS::getFileLastWriteDate(): File not known to the CompoundStorageService. Unable to forward to underlying StorageService");
         }
 
-        auto designated_storage_service = std::dynamic_pointer_cast<SimpleStorageService>(this->file_location_mapping[file]->getStorageService());
-        if (designated_storage_service) {
-            return designated_storage_service->getFileLastWriteDate(location);
-        } else {
-            return -1;
+        for (const auto& location : designated_locations) {
+            auto designated_storage_service = std::dynamic_pointer_cast<SimpleStorageService>(location->getStorageService());
+            if (designated_storage_service)
+                return designated_storage_service->getFileLastWriteDate(location);
         }
+
+        return 0.0; // FIX THAT.
     }
 
     /**
@@ -699,16 +1204,13 @@ namespace wrench {
      * @return true if the file is present, false otherwise
      */
     bool CompoundStorageService::hasFile(const std::shared_ptr<FileLocation> &location) {
-        auto file_location = this->lookupFileLocation(location->getFile());
-        if (!file_location) {
-            WRENCH_DEBUG("hasFile: File %s not found", location->getFile()->getID().c_str());
+        auto file_location = this->lookupFileLocation(location);
+        if (file_location.empty()) {
+            WRENCH_INFO("CSS::hasFile(): File %s not found", location->getFile()->getID().c_str());
             return false;
         }
-        if (file_location->getPath() != location->getPath()) {
-            WRENCH_DEBUG("hasFile: File %s found, but path %s doesn't match internal path %s",
-                         location->getFile()->getID().c_str(), location->getPath().c_str(), file_location->getPath().c_str());
-            return false;
-        }
+
+        // check internal path as well
 
         return true;
     }
@@ -741,6 +1243,44 @@ namespace wrench {
             return false;
         }
         return false;
+    }
+
+
+    void CompoundStorageService::traceInternalStorageUse(IOAction action, const std::vector<std::shared_ptr<FileLocation>> &locations) {
+
+        auto ts = S4U_Simulation::getClock();
+        AllocationTrace trace;
+        trace.act = action;
+        trace.ts = ts;
+
+        if (locations.empty()) {
+
+            for (const auto& storage : this->storage_services) {
+                for (const auto& storage_service : storage.second) {
+                    DiskUsage disk_usage;
+                    disk_usage.service = storage_service;
+                    disk_usage.load = storage_service->getLoad();                       // number of concurrent reads
+                    disk_usage.free_space = storage_service->traceTotalFreeSpace();
+                    trace.disk_usage.push_back(disk_usage);
+                }
+            }
+    
+        } else {
+
+            for (const auto &location: locations) {
+                auto storage_service = location->getStorageService();
+                DiskUsage disk_usage;
+                disk_usage.service = storage_service;
+                disk_usage.file_name = location->getFile()->getID();
+                disk_usage.load = storage_service->getLoad();                           // number of concurrent reads
+                disk_usage.free_space = storage_service->traceTotalFreeSpace();
+                trace.disk_usage.push_back(disk_usage);
+            }
+
+        }
+
+        this->internal_storage_use.push_back(std::make_pair(ts, trace));
+
     }
 
 };// namespace wrench

--- a/src/wrench/services/storage/compound/CompoundStorageServiceMessage.cpp
+++ b/src/wrench/services/storage/compound/CompoundStorageServiceMessage.cpp
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2017. The WRENCH Team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+
+#include "wrench/services/storage/compound/CompoundStorageServiceMessage.h"
+
+#include <utility>
+
+namespace wrench {
+
+    /**
+     * @brief Constructor
+     * @param payload: the message size in bytes
+     */
+    CompoundStorageServiceMessage::CompoundStorageServiceMessage(double payload) : StorageServiceMessage(payload) {}
+
+    /**
+    * @brief Constructor
+    * @param answer_mailbox: the mailbox to which to send the answer
+    * @param file: the file for which storage allocation is requested
+    *
+    * @throw std::invalid_argument
+    */
+    CompoundStorageAllocationRequestMessage::CompoundStorageAllocationRequestMessage(simgrid::s4u::Mailbox *answer_mailbox,
+                                                                                                 std::shared_ptr<DataFile> file, double payload)
+        : CompoundStorageServiceMessage(payload) {
+#ifdef WRENCH_INTERNAL_EXCEPTIONS
+        if (answer_mailbox == nullptr) {
+            throw std::invalid_argument(
+                    "CompoundStorageStorageSelectionRequestMessage::CompoundStorageStorageSelectionRequestMessage(): Invalid arguments");
+        }
+#endif
+        this->answer_mailbox = answer_mailbox;
+        this->file = file;
+    }
+
+    /**
+     * @brief Constructor
+     * @param locations: Existing or newly allocated FileLocations for requested file
+     * @param payload: the message size in bytes
+     *
+     * @throw std::invalid_argument
+     */
+    CompoundStorageAllocationAnswerMessage::CompoundStorageAllocationAnswerMessage(
+            std::vector<std::shared_ptr<FileLocation>> locations, double payload)
+        : CompoundStorageServiceMessage(payload) {
+        this->locations = locations;
+    }
+
+        /**
+    * @brief Constructor
+    * @param answer_mailbox: the mailbox to which to send the answer
+    * @param file: the file for which storage allocation is requested
+    *
+    * @throw std::invalid_argument
+    */
+    CompoundStorageLookupRequestMessage::CompoundStorageLookupRequestMessage(simgrid::s4u::Mailbox *answer_mailbox,
+                                                                             std::shared_ptr<DataFile> file, double payload)
+        : CompoundStorageServiceMessage(payload) {
+#ifdef WRENCH_INTERNAL_EXCEPTIONS
+        if (answer_mailbox == nullptr) {
+            throw std::invalid_argument(
+                    "CompoundStorageStorageSelectionRequestMessage::CompoundStorageStorageSelectionRequestMessage(): Invalid arguments");
+        }
+#endif
+        this->answer_mailbox = answer_mailbox;
+        this->file = file;
+    }
+
+    /**
+     * @brief Constructor
+     * @param locations: Known FileLocations for requested file
+     * @param payload: the message size in bytes
+     *
+     * @throw std::invalid_argument
+     */
+    CompoundStorageLookupAnswerMessage::CompoundStorageLookupAnswerMessage(
+            std::vector<std::shared_ptr<FileLocation>> locations, double payload)
+        : CompoundStorageServiceMessage(payload) {
+        this->locations = locations;
+    }
+
+}// namespace wrench

--- a/src/wrench/services/storage/compound/CompoundStorageServiceMessagePayload.cpp
+++ b/src/wrench/services/storage/compound/CompoundStorageServiceMessagePayload.cpp
@@ -11,5 +11,6 @@
 
 namespace wrench {
 
+    SET_MESSAGEPAYLOAD_NAME(CompoundStorageServiceMessagePayload, STORAGE_SELECTION_PAYLOAD);
 
 };

--- a/src/wrench/services/storage/compound/CompoundStorageServiceProperty.cpp
+++ b/src/wrench/services/storage/compound/CompoundStorageServiceProperty.cpp
@@ -11,7 +11,7 @@
 
 namespace wrench {
 
+    SET_PROPERTY_NAME(CompoundStorageServiceProperty, MAX_ALLOCATION_CHUNK_SIZE);
 
-    SET_PROPERTY_NAME(CompoundStorageServiceProperty, STORAGE_SELECTION_METHOD);
 
 };

--- a/src/wrench/services/storage/simple/SimpleStorageService.cpp
+++ b/src/wrench/services/storage/simple/SimpleStorageService.cpp
@@ -214,6 +214,19 @@ namespace wrench {
     }
 
     /**
+     * @brief Return current total free space from all mount point (in zero simulation time)
+     *        for IO tracing purpose.
+     * @return total free space in bytes
+    */
+    double SimpleStorageService::traceTotalFreeSpace() {
+        double free_space = 0;
+        for (auto const &mp: this->file_systems) {
+            free_space += mp.second->getFreeSpace();
+        }
+        return free_space;
+    }
+
+    /**
      * @brief Determine whether the storage service has multiple mount points
      * @return true if multiple mount points, false otherwise
      */

--- a/test/services/storage_services/CompoundStorageService/CompoundStorageServiceFunctionalTest.cpp
+++ b/test/services/storage_services/CompoundStorageService/CompoundStorageServiceFunctionalTest.cpp
@@ -30,15 +30,29 @@ public:
     std::shared_ptr<wrench::DataFile> file_500;
     std::shared_ptr<wrench::DataFile> file_1000;
 
-    std::shared_ptr<wrench::SimpleStorageService> simple_storage_service_100 = nullptr;
-    std::shared_ptr<wrench::SimpleStorageService> simple_storage_service_510 = nullptr;
-    std::shared_ptr<wrench::SimpleStorageService> simple_storage_service_1000 = nullptr;
+    // External storage
+    std::shared_ptr<wrench::SimpleStorageService> simple_storage_service_external = nullptr;
+
+    // Services for disks of node SimpleStorageHost0 
+    std::shared_ptr<wrench::SimpleStorageService> simple_storage_service_100_0 = nullptr;
+    std::shared_ptr<wrench::SimpleStorageService> simple_storage_service_510_0 = nullptr;
+    std::shared_ptr<wrench::SimpleStorageService> simple_storage_service_1000_0 = nullptr;
+    // Services for disks of node SimpleStorageHost1 
+    std::shared_ptr<wrench::SimpleStorageService> simple_storage_service_100_1 = nullptr;
+    std::shared_ptr<wrench::SimpleStorageService> simple_storage_service_510_1 = nullptr;
+    std::shared_ptr<wrench::SimpleStorageService> simple_storage_service_1000_1 = nullptr;
+
     std::shared_ptr<wrench::CompoundStorageService> compound_storage_service = nullptr;
 
     std::shared_ptr<wrench::ComputeService> compute_service = nullptr;
 
+
+    void do_CopyToCSS_test();
+    void do_WriteToCSS_test();
+    void do_CopyFromCSS_test();
+    void do_fullJob_test();
+
     void do_BasicFunctionality_test();
-    void do_BasicInterceptFunctionality_test();
     void do_BasicError_test();
 
 protected:
@@ -112,6 +126,705 @@ protected:
 };
 
 
+/* For testing purpose, dummy rr StorageSelectionStrategyCallback */
+std::shared_ptr<wrench::FileLocation> defaultStorageServiceSelection(
+        const std::shared_ptr<wrench::DataFile> &file,
+        const std::map<std::string, std::vector<std::shared_ptr<wrench::StorageService>>> &resources,
+        const std::map<std::shared_ptr<wrench::DataFile>, std::vector<std::shared_ptr<wrench::FileLocation>>> &mapping,
+        const std::vector<std::shared_ptr<wrench::FileLocation>>& previous_allocations) {
+
+    // Init round-robin
+    static auto last_selected_server = resources.begin()->first;
+    static auto internal_disk_selection = 0;
+    // static auto call_count = 0;
+    // std::cout << "# Call count 1: "<< std::to_string(call_count) << std::endl;
+    auto capacity_req = file->getSize();
+    std::shared_ptr<wrench::FileLocation> designated_location = nullptr;
+    // std::cout << "Calling on the rrStorageSelectionStrategy for file " << file->getID() << " (" << std::to_string(file->getSize()) << "B)" << std::endl;
+    auto current = resources.find(last_selected_server);
+    auto current_disk_selection = internal_disk_selection;
+    // std::cout << "Last selected server " << last_selected_server << std::endl;
+    // std::cout << "Starting from server " << current->first << std::endl;
+    // std::cout << "Internal disk selection " << std::to_string(internal_disk_selection) << std::endl;
+
+    auto continue_disk_loop = true;
+
+    do {
+
+        // std::cout << "Considering disk index " << std::to_string(current_disk_selection) << std::endl;
+        auto nb_of_local_disks = current->second.size();
+        auto storage_service = current->second[current_disk_selection % nb_of_local_disks];
+        // std::cout << "- Looking at storage service " << storage_service->getName() << std::endl;
+
+        auto free_space = storage_service->getTotalFreeSpace();
+        // std::cout << "- It has " << free_space << "B of free space" << std::endl;
+
+        if (free_space >= capacity_req) {
+            designated_location = wrench::FileLocation::LOCATION(std::shared_ptr<wrench::StorageService>(storage_service), file);
+            // std::cout << "Chose server " << current->first << storage_service->getBaseRootPath() << std::endl;
+            // Update for next function call
+            std::advance(current, 1);
+            if (current == resources.end()) {
+                current = resources.begin();
+                current_disk_selection++;
+            }
+            last_selected_server = current->first;
+            internal_disk_selection = current_disk_selection;
+            // std::cout << "Next first server will be " << last_selected_server << std::endl;
+            break;
+        }
+
+        std::advance(current, 1);
+        if (current == resources.end()) {
+            current = resources.begin();
+            current_disk_selection++;
+        }
+        if (current_disk_selection > (internal_disk_selection + nb_of_local_disks + 1)) {
+            // std::cout << "Stopping continue_disk_loop" << std::endl;
+            continue_disk_loop = false;
+        }
+        // std::cout << "Next server will be " << current->first << std::endl;
+    } while ((current->first != last_selected_server) or (continue_disk_loop));
+
+    // call_count++;
+    // std::cout << "# Call count 2: "<< std::to_string(call_count) << std::endl;
+
+    // std::cout << "smartStorageSelectionStrategy has done its work." << std::endl;
+    return designated_location;
+}
+
+
+/**********************************************************************/
+/**  COPY TO CSS TEST                                                **/
+/**********************************************************************/
+
+
+class CSSCopyToCSSTestCtrl : public wrench::ExecutionController {
+
+public:
+    CSSCopyToCSSTestCtrl(CompoundStorageServiceFunctionalTest *test,
+                         const std::string &hostname) : wrench::ExecutionController(hostname, "test"), test(test) {
+    }
+
+private:
+    CompoundStorageServiceFunctionalTest *test;
+
+    int main() override {
+
+        wrench::S4U_Simulation::computeZeroFlop();
+
+        auto job_manager = this->createJobManager();
+        auto job = job_manager->createCompoundJob("copyToCSSJob");
+
+        // ## Stage file on external storage    
+        wrench::StorageService::createFileAtLocation(wrench::FileLocation::LOCATION(test->simple_storage_service_external, "/disk1000", test->file_100));
+        // Copy to CSS
+        auto fileCopyAction = job->addFileCopyAction(
+            "stagingCopy_1", 
+            wrench::FileLocation::LOCATION(test->simple_storage_service_external, "/disk1000", test->file_100),
+            wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_100)
+        );
+
+        // Read from CSS
+        auto fileReadAction = job->addFileReadAction("fRead_1", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_100));
+        job->addActionDependency(fileCopyAction, fileReadAction);
+
+        // ## Stage file on external storage (WITH STRIPPING)
+        wrench::StorageService::createFileAtLocation(wrench::FileLocation::LOCATION(test->simple_storage_service_external, "/disk1000", test->file_500));
+        // Copy to CSS
+        auto fileCopyAction_2 = job->addFileCopyAction(
+            "stagingCopy_2", 
+            wrench::FileLocation::LOCATION(test->simple_storage_service_external, "/disk1000", test->file_500),
+            wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500)
+        );
+        job->addActionDependency(fileReadAction, fileCopyAction_2);
+
+        // Read from CSS
+        auto fileReadAction_2 = job->addFileReadAction("fRead_2", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500));
+        job->addActionDependency(fileCopyAction_2, fileReadAction_2);
+
+        job_manager->submitJob(job, test->compute_service, {});
+        std::shared_ptr<wrench::ExecutionEvent> event = this->waitForNextEvent();
+
+        if (not std::dynamic_pointer_cast<wrench::CompoundJobCompletedEvent>(event)) {
+            throw std::runtime_error("Unexpected workflow execution event: " + event->toString());
+        }
+
+        if (job->getState() != wrench::CompoundJob::State::COMPLETED) {
+            throw std::runtime_error("Unexpected job state: " + job->getStateAsString());
+        }
+
+        // Check that all file copies worked as intended
+        auto tmp_mailbox = wrench::S4U_Mailbox::getTemporaryMailbox();
+        auto read_file_copy_1 = test->compound_storage_service->lookupFileLocation(test->file_100, tmp_mailbox);
+        if (read_file_copy_1.size() != 1) {
+            throw std::runtime_error("Lookup returned an incorrect number of parts for file_100 on CSS");
+        }
+        if (read_file_copy_1[0]->getStorageService()->getBaseRootPath() != "/disk510/") {
+            throw std::runtime_error("file_100 should be on /disk510/");
+        }
+
+        auto read_file_copy_2 = test->compound_storage_service->lookupFileLocation(test->file_500, tmp_mailbox);
+        if (read_file_copy_2.size() != 2) {
+            throw std::runtime_error("Lookup returned an incorrect number of parts for file_500 on CSS");
+        }
+        for (auto part : read_file_copy_2) {
+            auto file_location = wrench::FileLocation::LOCATION(test->simple_storage_service_external, part->getFile());
+            if (test->simple_storage_service_external->hasFile(file_location)){
+                throw std::runtime_error("Src file part from stripping shouldn't be on source anymore");
+            }
+        }
+        if (read_file_copy_2[0]->getStorageService()->getBaseRootPath() != "/disk1000/") {
+            throw std::runtime_error("file_500_part_0 should be on /disk1000/");
+        }
+        if (read_file_copy_2[1]->getStorageService()->getBaseRootPath() != "/disk510/") {
+            throw std::runtime_error("file_500_part_1 should be on /disk510/");
+        }
+
+        auto external_free_space = test->simple_storage_service_external->getTotalFreeSpace();
+        if (external_free_space != 400) {
+            throw std::runtime_error("Residual data on external free space not cleaned up after stropped copy");
+        }
+    
+        wrench::S4U_Mailbox::retireTemporaryMailbox(tmp_mailbox);
+
+        return 0;
+    }
+
+};
+
+
+TEST_F(CompoundStorageServiceFunctionalTest, BasicFunctionalityCopyToCSS) {
+    DO_TEST_WITH_FORK(do_CopyToCSS_test);
+}
+
+void CompoundStorageServiceFunctionalTest::do_CopyToCSS_test() {
+
+    // Create and initialize a simulation
+    auto simulation = wrench::Simulation::createSimulation();
+
+    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+    // xbt_log_control_set("wrench_core_compound_storage_system.thresh:debug");
+    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+    // xbt_log_control_set("wrench_core_storage_service.thres:debug");
+
+    int argc = 1;
+    char **argv = (char **) calloc(argc, sizeof(char *));
+    argv[0] = strdup("unit_test");
+    // argv[1] = strdup("--wrench-full-log");
+
+    // Setting up simulation and platform
+    ASSERT_NO_THROW(simulation->init(&argc, argv));
+    ASSERT_NO_THROW(simulation->instantiatePlatform(platform_file_path));
+
+    ASSERT_NO_THROW(
+            compute_service = simulation->add(
+                    new wrench::BareMetalComputeService("ComputeHost",
+                                                        {std::make_pair("ComputeHost", std::make_tuple(wrench::ComputeService::ALL_CORES,
+                                                                                                 wrench::ComputeService::ALL_RAM))},
+                                                        {})));
+
+    // Create some simple storage services (unbufferized)
+    ASSERT_NO_THROW(simple_storage_service_510_0 = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost0", {"/disk510"},
+                                                                                     {}, {})));
+    ASSERT_NO_THROW(simple_storage_service_1000_0 = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost0", {"/disk1000"},
+                                                                                     {}, {})));
+
+    ASSERT_NO_THROW(simple_storage_service_external = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost1", {"/disk1000"},
+                                                                                     {}, {})));
+    
+    // Create a valid Compound Storage Service, without user provided callback (no intercept capabilities)
+    ASSERT_NO_THROW(compound_storage_service = simulation->add(
+                            new wrench::CompoundStorageService(
+                                "CompoundStorageHost", 
+                                {simple_storage_service_510_0, simple_storage_service_1000_0}, 
+                                defaultStorageServiceSelection, 
+                                {{wrench::CompoundStorageServiceProperty::MAX_ALLOCATION_CHUNK_SIZE, "400"}}, {})
+                            ));
+
+    // Create a Controler
+    std::shared_ptr<wrench::ExecutionController> wms = nullptr;
+    ASSERT_NO_THROW(wms = simulation->add(
+                            new CSSCopyToCSSTestCtrl(this, "CompoundStorageHost")));
+
+    // Tun the simulation
+    ASSERT_NO_THROW(simulation->launch());
+
+    for (int i = 0; i < argc; i++)
+        free(argv[i]);
+    free(argv);
+}
+
+
+
+/**********************************************************************/
+/**  WRITE TO CSS TEST                                                **/
+/**********************************************************************/
+
+
+class CSSWriteToCSSTestCtrl : public wrench::ExecutionController {
+
+public:
+    CSSWriteToCSSTestCtrl(CompoundStorageServiceFunctionalTest *test,
+                         const std::string &hostname) : wrench::ExecutionController(hostname, "test"), test(test) {
+    }
+
+private:
+    CompoundStorageServiceFunctionalTest *test;
+
+    int main() override {
+
+        wrench::S4U_Simulation::computeZeroFlop();
+
+        auto job_manager = this->createJobManager();
+        auto job = job_manager->createCompoundJob("writeToCSSJob");
+
+        // Write to CSS
+        auto fileWriteAction_1 = job->addFileWriteAction("fWrite_1", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_100));
+
+        // Write to CSS (with stripping)
+        auto fileWriteAction_2 = job->addFileWriteAction("fWrite_2", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500));
+        job->addActionDependency(fileWriteAction_1, fileWriteAction_2);
+
+        job_manager->submitJob(job, test->compute_service, {});
+        std::shared_ptr<wrench::ExecutionEvent> event = this->waitForNextEvent();
+
+        if (not std::dynamic_pointer_cast<wrench::CompoundJobCompletedEvent>(event)) {
+            throw std::runtime_error("Unexpected workflow execution event: " + event->toString());
+        }
+
+        if (job->getState() != wrench::CompoundJob::State::COMPLETED) {
+            throw std::runtime_error("Unexpected job state: " + job->getStateAsString());
+        }
+
+        auto tmp_mailbox = wrench::S4U_Mailbox::getTemporaryMailbox();
+        // Check that all file copies worked as intended
+        auto write_file_lookup_1 = test->compound_storage_service->lookupFileLocation(test->file_100, tmp_mailbox);
+        if (write_file_lookup_1.size() != 1) {
+            throw std::runtime_error("Lookup returned an incorrect number of parts for file_500 on CSS");
+        }
+        if (write_file_lookup_1[0]->getStorageService()->getBaseRootPath() != "/disk510/") {
+            throw std::runtime_error("file_100 should be on /disk510/");
+        }
+
+        auto write_file_lookup_2 = test->compound_storage_service->lookupFileLocation(test->file_500, tmp_mailbox);
+        if (write_file_lookup_2.size() != 2) {
+            throw std::runtime_error("Lookup returned an incorrect number of parts for file_500 on CSS");
+        }
+        if (write_file_lookup_2[0]->getStorageService()->getBaseRootPath() != "/disk1000/") {
+            throw std::runtime_error("file_500_part_0 should be on /disk1000/");
+        }
+        if (write_file_lookup_2[1]->getStorageService()->getBaseRootPath() != "/disk510/") {
+            throw std::runtime_error("file_500_part_1 should be on /disk510/");
+        }
+
+        wrench::S4U_Mailbox::retireTemporaryMailbox(tmp_mailbox);
+
+        return 0;
+    }
+
+};
+
+
+TEST_F(CompoundStorageServiceFunctionalTest, BasicFunctionalityWriteToCSS) {
+    DO_TEST_WITH_FORK(do_WriteToCSS_test);
+}
+
+void CompoundStorageServiceFunctionalTest::do_WriteToCSS_test() {
+
+    // Create and initialize a simulation
+    auto simulation = wrench::Simulation::createSimulation();
+
+    // xbt_log_control_set("wrench_core_storage_service.thres:debug");
+    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+    // xbt_log_control_set("wrench_core_compound_storage_system.thresh:debug");
+    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+
+    int argc = 1;
+    char **argv = (char **) calloc(argc, sizeof(char *));
+    argv[0] = strdup("unit_test");
+    // argv[1] = strdup("--wrench-full-log");
+
+    // Setting up simulation and platform
+    ASSERT_NO_THROW(simulation->init(&argc, argv));
+    ASSERT_NO_THROW(simulation->instantiatePlatform(platform_file_path));
+
+    ASSERT_NO_THROW(
+            compute_service = simulation->add(
+                    new wrench::BareMetalComputeService("ComputeHost",
+                                                        {std::make_pair("ComputeHost", std::make_tuple(wrench::ComputeService::ALL_CORES,
+                                                                                                 wrench::ComputeService::ALL_RAM))},
+                                                        {})));
+
+    // Create some simple storage services (unbufferized)
+    ASSERT_NO_THROW(simple_storage_service_510_0 = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost0", {"/disk510"},
+                                                                                     {}, {})));
+    ASSERT_NO_THROW(simple_storage_service_1000_0 = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost0", {"/disk1000"},
+                                                                                     {}, {})));
+    
+    // Create a valid Compound Storage Service, without user provided callback (no intercept capabilities)
+    ASSERT_NO_THROW(compound_storage_service = simulation->add(
+                            new wrench::CompoundStorageService(
+                                "CompoundStorageHost", 
+                                {simple_storage_service_510_0, simple_storage_service_1000_0}, 
+                                defaultStorageServiceSelection, 
+                                {{wrench::CompoundStorageServiceProperty::MAX_ALLOCATION_CHUNK_SIZE, "400"}}, {})
+                            ));
+
+    // Create a Controler
+    std::shared_ptr<wrench::ExecutionController> wms = nullptr;
+    ASSERT_NO_THROW(wms = simulation->add(
+                            new CSSWriteToCSSTestCtrl(this, "CompoundStorageHost")));
+
+    // Tun the simulation
+    ASSERT_NO_THROW(simulation->launch());
+
+    for (int i = 0; i < argc; i++)
+        free(argv[i]);
+    free(argv);
+}
+
+
+/**********************************************************************/
+/**  COPY FROM CSS TEST                                                **/
+/**********************************************************************/
+
+
+class CSSCopyFromCSSTestCtrl : public wrench::ExecutionController {
+
+public:
+    CSSCopyFromCSSTestCtrl(CompoundStorageServiceFunctionalTest *test,
+                         const std::string &hostname) : wrench::ExecutionController(hostname, "test"), test(test) {
+    }
+
+private:
+    CompoundStorageServiceFunctionalTest *test;
+
+    int main() override {
+
+        wrench::S4U_Simulation::computeZeroFlop();
+
+        auto job_manager = this->createJobManager();
+        auto job = job_manager->createCompoundJob("copyFromCSSJob");
+
+        // Write to CSS
+        auto fileWriteAction_1 = job->addFileWriteAction("fWrite_1", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_100));
+        // Copy to external storage
+        auto fileCopyAction_1 = job->addFileCopyAction("fCopy_1", 
+            wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_100),
+            wrench::FileLocation::LOCATION(test->simple_storage_service_external, "/disk1000", test->file_100)
+        );
+        job->addActionDependency(fileWriteAction_1, fileCopyAction_1);
+
+        // Write to CSS
+        auto fileWriteAction_2 = job->addFileWriteAction("fWrite_2", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500));
+        job->addActionDependency(fileCopyAction_1, fileWriteAction_2);
+        // Copy to external storage (with stripping)
+        auto fileCopyAction_2 = job->addFileCopyAction("fCopy_2", 
+            wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500),
+            wrench::FileLocation::LOCATION(test->simple_storage_service_external, "/disk1000", test->file_500)
+        );
+        job->addActionDependency(fileWriteAction_2, fileCopyAction_2);
+
+        job_manager->submitJob(job, test->compute_service, {});
+        std::shared_ptr<wrench::ExecutionEvent> event = this->waitForNextEvent();
+
+        if (not std::dynamic_pointer_cast<wrench::CompoundJobCompletedEvent>(event)) {
+            throw std::runtime_error("Unexpected workflow execution event: " + event->toString());
+        }
+
+        if (job->getState() != wrench::CompoundJob::State::COMPLETED) {
+            throw std::runtime_error("Unexpected job state: " + job->getStateAsString());
+        }
+
+        // Check that all file copies worked as intended
+        
+        auto tmp_mailbox = wrench::S4U_Mailbox::getTemporaryMailbox();
+
+        auto write_file_lookup_1 = test->compound_storage_service->lookupFileLocation(test->file_100, tmp_mailbox);
+        if (write_file_lookup_1.size() != 1) {
+            throw std::runtime_error("Lookup returned an incorrect number of parts for file_500 on CSS");
+        }
+        if (write_file_lookup_1[0]->getStorageService()->getBaseRootPath() != "/disk510/") {
+            throw std::runtime_error("file_100 should be on /disk510/");
+        }
+
+
+        if (!test->simple_storage_service_external->hasFile(wrench::FileLocation::LOCATION(test->simple_storage_service_external, "/disk1000", test->file_500))){
+            throw std::runtime_error("File 500 not found on external storage");
+        }
+        if (!test->simple_storage_service_external->hasFile(wrench::FileLocation::LOCATION(test->simple_storage_service_external, "/disk1000", test->file_100))){
+            throw std::runtime_error("File 100 not found on external storage");
+        }
+        if (test->simple_storage_service_external->getTotalFreeSpace() != 400) {
+            throw std::runtime_error("External storage doesn't have the expected free space (should be 400)");
+        }
+
+        auto write_file_lookup_2 = test->compound_storage_service->lookupFileLocation(test->file_500, tmp_mailbox);
+        if (write_file_lookup_2.size() != 2) {
+            throw std::runtime_error("Lookup returned an incorrect number of parts for file_500 on CSS");
+        }
+        if (write_file_lookup_2[0]->getStorageService()->getBaseRootPath() != "/disk1000/") {
+            throw std::runtime_error("file_500_part_0 should be on /disk1000/");
+        }
+        if (write_file_lookup_2[1]->getStorageService()->getBaseRootPath() != "/disk510/") {
+            throw std::runtime_error("file_500_part_1 should be on /disk510/");
+        }
+
+        wrench::S4U_Mailbox::retireTemporaryMailbox(tmp_mailbox);
+
+        return 0;
+    }
+
+};
+
+
+TEST_F(CompoundStorageServiceFunctionalTest, BasicFunctionalityCopyFromCSS) {
+    DO_TEST_WITH_FORK(do_CopyFromCSS_test);
+}
+
+void CompoundStorageServiceFunctionalTest::do_CopyFromCSS_test() {
+
+    // Create and initialize a simulation
+    auto simulation = wrench::Simulation::createSimulation();
+
+    // xbt_log_control_set("wrench_core_storage_service.thres:debug");
+    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+    // xbt_log_control_set("wrench_core_compound_storage_system.thresh:debug");
+    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+
+    int argc = 1;
+    char **argv = (char **) calloc(argc, sizeof(char *));
+    argv[0] = strdup("unit_test");
+    // argv[1] = strdup("--wrench-full-log");
+
+    // Setting up simulation and platform
+    ASSERT_NO_THROW(simulation->init(&argc, argv));
+    ASSERT_NO_THROW(simulation->instantiatePlatform(platform_file_path));
+
+    ASSERT_NO_THROW(
+            compute_service = simulation->add(
+                    new wrench::BareMetalComputeService("ComputeHost",
+                                                        {std::make_pair("ComputeHost", std::make_tuple(wrench::ComputeService::ALL_CORES,
+                                                                                                 wrench::ComputeService::ALL_RAM))},
+                                                        {})));
+
+    // Create some simple storage services (unbufferized)
+    ASSERT_NO_THROW(simple_storage_service_510_0 = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost0", {"/disk510"},
+                                                                                     {}, {})));
+    ASSERT_NO_THROW(simple_storage_service_1000_0 = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost0", {"/disk1000"},
+                                                                                     {}, {})));
+    
+    ASSERT_NO_THROW(simple_storage_service_external = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost1", {"/disk1000"},
+                                                                                     {}, {})));
+
+    // Create a valid Compound Storage Service, without user provided callback (no intercept capabilities)
+    ASSERT_NO_THROW(compound_storage_service = simulation->add(
+                            new wrench::CompoundStorageService(
+                                "CompoundStorageHost", 
+                                {simple_storage_service_510_0, simple_storage_service_1000_0}, 
+                                defaultStorageServiceSelection, 
+                                {{wrench::CompoundStorageServiceProperty::MAX_ALLOCATION_CHUNK_SIZE, "400"}}, {})
+                            ));
+
+    // Create a Controler
+    std::shared_ptr<wrench::ExecutionController> wms = nullptr;
+    ASSERT_NO_THROW(wms = simulation->add(
+                            new CSSCopyFromCSSTestCtrl(this, "CompoundStorageHost")));
+
+    // Tun the simulation
+    ASSERT_NO_THROW(simulation->launch());
+
+    for (int i = 0; i < argc; i++)
+        free(argv[i]);
+    free(argv);
+}
+
+
+/**********************************************************************/
+/**  FULL JOB TEST                                                **/
+/**********************************************************************/
+
+
+class CSSFullJobTestCtrl : public wrench::ExecutionController {
+
+public:
+    CSSFullJobTestCtrl(CompoundStorageServiceFunctionalTest *test,
+                         const std::string &hostname) : wrench::ExecutionController(hostname, "test"), test(test) {
+    }
+
+private:
+    CompoundStorageServiceFunctionalTest *test;
+
+    int main() override {
+
+        /**
+         *  - Create a file on external storage
+         *  - Copy from external storage to CSS storage (stripping on dest)
+         *  - Read parts of file from CSS
+         *  - Write results to CSS (stripped)
+         *  - Delete original file from external storage
+         *  - Archive results from CSS (stripped)  to external storage
+         *  - Delete all files from CSS
+         */
+
+        wrench::S4U_Simulation::computeZeroFlop();
+        std::vector<std::shared_ptr<wrench::Action>> actions;
+
+        auto job_manager = this->createJobManager();
+        auto job = job_manager->createCompoundJob("fullJob");
+
+        wrench::StorageService::createFileAtLocation(wrench::FileLocation::LOCATION(test->simple_storage_service_external, "/disk1000", test->file_1000));
+        auto stagingAction = job->addFileCopyAction(
+            "stagingCopy_1000", 
+            wrench::FileLocation::LOCATION(test->simple_storage_service_external, test->file_1000),
+            wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1000)
+        );
+        actions.push_back(stagingAction);
+        auto fileReadAction = job->addFileReadAction("fRead_1000", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1000));
+        actions.push_back(fileReadAction);
+        job->addActionDependency(stagingAction, fileReadAction);
+        
+        // Compute would go here
+
+        auto fileWriteAction = job->addFileWriteAction("fWrite_500", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500));
+        actions.push_back(fileWriteAction);
+        job->addActionDependency(fileReadAction, fileWriteAction);
+
+        // Free some space on the external storage
+        auto deleteExternalFileAction = job->addFileDeleteAction("delExt_1000", wrench::FileLocation::LOCATION(test->simple_storage_service_external, test->file_1000));
+        actions.push_back(deleteExternalFileAction);
+        job->addActionDependency(fileWriteAction, deleteExternalFileAction);
+
+        // "Archive" hypothetical results to external storage
+        auto archiveAction = job->addFileCopyAction(
+                "archiveCopy_500", 
+                wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500),
+                wrench::FileLocation::LOCATION(test->simple_storage_service_external,  test->file_500)
+        );
+        actions.push_back(archiveAction);
+        job->addActionDependency(deleteExternalFileAction, archiveAction);
+
+        // Cleanup CSS (initial file 1000 and written file 500)
+        auto deleteCSS1000Action = job->addFileDeleteAction("delRF_1000", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1000)); 
+        actions.push_back(deleteCSS1000Action);
+        job->addActionDependency(archiveAction, deleteCSS1000Action);
+
+        auto deleteCSS500Action = job->addFileDeleteAction("delRF_500", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500)); 
+        actions.push_back(deleteCSS500Action);
+        job->addActionDependency(deleteCSS1000Action, deleteCSS500Action);
+
+        job_manager->submitJob(job, test->compute_service);
+        std::shared_ptr<wrench::ExecutionEvent> event = this->waitForNextEvent();
+
+        for (auto const &a : actions) {
+            if (a->getState() != wrench::Action::State::COMPLETED) {
+                auto exc_msg = "Action " + a->getName() + " did not complete";
+                throw std::runtime_error(exc_msg);
+            }
+        }
+
+        if (!test->simple_storage_service_external->hasFile(wrench::FileLocation::LOCATION(test->simple_storage_service_external, "/disk1000", test->file_500))){
+            throw std::runtime_error("File 500 not found on external storage");
+        }
+
+        auto external_free_space = test->simple_storage_service_external->getTotalFreeSpace();
+        if (external_free_space != 500) {
+            auto exc_msg = "External free space has " + std::to_string(external_free_space) + "B of free space."
+                            "It should have 500B";
+            throw std::runtime_error(exc_msg);
+        }
+
+        auto tmp_mailbox = wrench::S4U_Mailbox::getTemporaryMailbox();
+        auto css_File_500 = test->compound_storage_service->lookupFileLocation(test->file_500, tmp_mailbox);
+        if (!css_File_500.empty()) {
+            throw std::runtime_error("file_500 is still present on CSS, it shouldn't");
+        }
+
+        wrench::S4U_Mailbox::retireTemporaryMailbox(tmp_mailbox);
+
+        return 0;
+    }
+};
+
+
+TEST_F(CompoundStorageServiceFunctionalTest, BasicFunctionalityFullJob) {
+    DO_TEST_WITH_FORK(do_fullJob_test);
+}
+
+void CompoundStorageServiceFunctionalTest::do_fullJob_test() {
+
+    // Create and initialize a simulation
+    auto simulation = wrench::Simulation::createSimulation();
+
+    // xbt_log_control_set("wrench_core_storage_service.thres:debug");
+    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+    // xbt_log_control_set("wrench_core_compound_storage_system.thresh:debug");
+    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+
+    int argc = 1;
+    char **argv = (char **) calloc(argc, sizeof(char *));
+    argv[0] = strdup("unit_test");
+    // argv[1] = strdup("--wrench-full-log");
+
+    // Setting up simulation and platform
+    ASSERT_NO_THROW(simulation->init(&argc, argv));
+    ASSERT_NO_THROW(simulation->instantiatePlatform(platform_file_path));
+
+    ASSERT_NO_THROW(
+            compute_service = simulation->add(
+                    new wrench::BareMetalComputeService("ComputeHost",
+                                                        {std::make_pair("ComputeHost", std::make_tuple(wrench::ComputeService::ALL_CORES,
+                                                                                                 wrench::ComputeService::ALL_RAM))},
+                                                        {})));
+
+    // Create some simple storage services (unbufferized)
+    ASSERT_NO_THROW(simple_storage_service_510_0 = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost0", {"/disk510"},
+                                                                                     {}, {})));
+    ASSERT_NO_THROW(simple_storage_service_1000_0 = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost0", {"/disk1000"},
+                                                                                     {}, {})));
+    
+    ASSERT_NO_THROW(simple_storage_service_100_1 = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost1", {"/disk100"},
+                                                                                     {}, {})));
+
+    ASSERT_NO_THROW(simple_storage_service_external = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost1", {"/disk1000"},
+                                                                                     {}, {})));
+
+    // Create a valid Compound Storage Service, without user provided callback (no intercept capabilities)
+    ASSERT_NO_THROW(compound_storage_service = simulation->add(
+                            new wrench::CompoundStorageService(
+                                "CompoundStorageHost", 
+                                {simple_storage_service_510_0, simple_storage_service_100_1, simple_storage_service_1000_0}, 
+                                defaultStorageServiceSelection, 
+                                {{wrench::CompoundStorageServiceProperty::MAX_ALLOCATION_CHUNK_SIZE, "100"}}, {})
+                            ));
+
+    // Create a Controler
+    std::shared_ptr<wrench::ExecutionController> wms = nullptr;
+    ASSERT_NO_THROW(wms = simulation->add(
+                            new CSSFullJobTestCtrl(this, "CompoundStorageHost")));
+
+    // Tun the simulation
+    ASSERT_NO_THROW(simulation->launch());
+
+    for (int i = 0; i < argc; i++)
+        free(argv[i]);
+    free(argv);
+}
+
+
 /**********************************************************************/
 /**  BASIC FUNCTIONALITY SIMULATION TEST                             **/
 /**********************************************************************/
@@ -132,11 +845,19 @@ private:
 
         // Retrieve internal SimpleStorageServices
         auto simple_storage_services = test->compound_storage_service->getAllServices();
-        std::set<std::shared_ptr<wrench::StorageService>> expected_services{test->simple_storage_service_100, test->simple_storage_service_510};
-        if (simple_storage_services != expected_services) {
-            throw std::runtime_error("The list of returned simple storage services is incorrect");
+        std::map<std::string, std::vector<std::shared_ptr<wrench::StorageService>>> expected_services{
+            {"SimpleStorageHost0", {test->simple_storage_service_100_0}}, 
+            {"SimpleStorageHost1", {test->simple_storage_service_510_1}}
+        };
+        
+        for (auto const& svc: simple_storage_services) {
+            if (expected_services.find(svc.first) == expected_services.end()) {
+                throw std::runtime_error("Can't find one of the hosts in the services list");
+            }
+            if (expected_services[svc.first] != svc.second) {
+                throw std::runtime_error("One of the Storage hosts has a different list of associated disk services than expected");
+            }
         }
-
 
         // Verify synchronous request for current free space (currently same as capacity, as no file has been placed on internal services)
         auto expected_capacity = 100.0 + 510.0;
@@ -144,7 +865,6 @@ private:
         if (free_space != expected_capacity) {
             throw std::runtime_error("'Free Space' available to CompoundStorageService is incorrect");
         }
-
         // Verify that total space is correct
         auto capacity = test->compound_storage_service->getTotalSpace();
         if (capacity != expected_capacity) {
@@ -171,7 +891,6 @@ private:
             } catch (std::invalid_argument &e) {}
         }
 
-
         // CompoundStorageServer should never be a scratch space (at init or set as later)
         if (test->compound_storage_service->isScratch() == true) {
             throw std::runtime_error("CompoundStorageService should never have isScratch == true");
@@ -185,67 +904,73 @@ private:
         if (test->compound_storage_service->isBufferized()) {
             throw std::runtime_error("CompoundStorageService shouldn't be bufferized");
         }
-
         // ## Test multiple messages that should answer with a failure cause, and in turn generate an ExecutionException
         // on caller's side
 
         // File copy, CSS as src, file not known:
         {
-            auto file_1_loc_ss = wrench::FileLocation::LOCATION(test->simple_storage_service_100, test->file_1);
+            auto file_1_loc_ss = wrench::FileLocation::LOCATION(test->simple_storage_service_100_0, test->file_1);
             wrench::StorageService::createFileAtLocation(file_1_loc_ss);
             auto file_1_loc_css = wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1);
-
             try {
                 wrench::StorageService::copyFile(file_1_loc_css, file_1_loc_ss);
                 throw std::runtime_error("File doesn't exist on CSS, copy with CSS as src should be impossible");
             } catch (wrench::ExecutionException &e) {
-                if (!std::dynamic_pointer_cast<wrench::NotAllowed>(e.getCause())) {
-                    throw std::runtime_error("Exception cause should have been 'NotAllowed'");
+                if (!std::dynamic_pointer_cast<wrench::FileNotFound>(e.getCause())) {
+                    throw std::runtime_error("Exception cause should have been 'FileNotFound'");
                 }
             }
-            test->simple_storage_service_100->deleteFile(file_1_loc_ss);
+            test->simple_storage_service_100_0->deleteFile(file_1_loc_ss);
         }
 
         // File copy, CSS as dst, file can't be allocated (no callback provided) - src file exists:
         {
-            auto file_1_loc_ss = wrench::FileLocation::LOCATION(test->simple_storage_service_100, test->file_1);
+            auto file_1_loc_ss = wrench::FileLocation::LOCATION(test->simple_storage_service_100_0, test->file_1);
             wrench::StorageService::createFileAtLocation(file_1_loc_ss);
             auto file_1_loc_css = wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1);
-
             try {
                 wrench::StorageService::copyFile(file_1_loc_ss, file_1_loc_css);
                 throw std::runtime_error("File doesn't exist and can't be allocated on CSS, copy with CSS as dst should be impossible");
             } catch (wrench::ExecutionException &e) {
-                if (!std::dynamic_pointer_cast<wrench::NotAllowed>(e.getCause())) {
-                    throw std::runtime_error("Exception cause should have been 'NotAllowed' because no storage_selection callback was provided");
+                if (!std::dynamic_pointer_cast<wrench::StorageServiceNotEnoughSpace>(e.getCause())) {
+                    throw std::runtime_error("Exception cause should have been 'StorageServiceNotEnoughSpace' (which is slightly incorrect in this case)");
                 }
             }
-            test->simple_storage_service_100->deleteFile(file_1_loc_ss);
+            test->simple_storage_service_100_0->deleteFile(file_1_loc_ss);
         }
 
-        auto file_1_loc_ss = wrench::FileLocation::LOCATION(test->simple_storage_service_100, test->file_1);
+        auto file_1_loc_ss = wrench::FileLocation::LOCATION(test->simple_storage_service_100_0, test->file_1);
         auto file_1_loc_css = wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1);
-
         try {
             wrench::StorageService::deleteFileAtLocation(file_1_loc_css);
             throw std::runtime_error("Should not be able to delete file from a CompoundStorageService if it has not first been written / copied to it");
-        } catch (wrench::ExecutionException &) {}
+        } catch (wrench::ExecutionException &e) {
+            if (!std::dynamic_pointer_cast<wrench::FileNotFound>(e.getCause())) {
+                throw std::runtime_error("Exception cause should have been 'FileNotFound'");
+            }
+        }
 
         try {
             wrench::StorageService::readFileAtLocation(file_1_loc_css);
             throw std::runtime_error("Should not be able to read file from a CompoundStorageService if it has not first been written / copied to it");
-        } catch (wrench::ExecutionException &) {}
-
+        } catch (wrench::ExecutionException &e) {
+            if (!std::dynamic_pointer_cast<wrench::FileNotFound>(e.getCause())) {
+                throw std::runtime_error("Exception cause should have been 'FileNotFound'");
+            }
+        }
 
         try {
             wrench::StorageService::writeFileAtLocation(file_1_loc_css);
             throw std::runtime_error("Should not be able to write file on a CompoundStorageService because no selection callback was provided");
-        } catch (wrench::ExecutionException &e) {}
-
+        } catch (wrench::ExecutionException &e) {
+            if (!std::dynamic_pointer_cast<wrench::StorageServiceNotEnoughSpace>(e.getCause())) {
+                throw std::runtime_error("Exception cause should have been 'StorageServiceNotEnoughSpace' (which is slightly incorrect in this case)");
+            }
+        }
 
         // This one simply answers that the file was not found
         if (wrench::StorageService::lookupFileAtLocation(file_1_loc_css))
-            throw std::runtime_error("Should not be able to lookup file from a CompoundStorageService if it has not been written/copied to it first");
+            throw std::runtime_error("Should not be able to lookup file from a CompoundStorageService if it has not been written/copied to it first");  
 
         return 0;
     }
@@ -260,10 +985,10 @@ void CompoundStorageServiceFunctionalTest::do_BasicFunctionality_test() {
     // Create and initialize a simulation
     auto simulation = wrench::Simulation::createSimulation();
 
-    //    xbt_log_control_set("wrench_core_storage_service.thres:debug");
-    //    xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
-    //    xbt_log_control_set("wrench_core_compound_storage_system.thresh:debug");
-    //    xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+    // xbt_log_control_set("wrench_core_storage_service.thres:debug");
+    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
+    // xbt_log_control_set("wrench_core_compound_storage_system.thresh:debug");
+    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
 
     int argc = 1;
     char **argv = (char **) calloc(argc, sizeof(char *));
@@ -274,267 +999,49 @@ void CompoundStorageServiceFunctionalTest::do_BasicFunctionality_test() {
     ASSERT_NO_THROW(simulation->init(&argc, argv));
     ASSERT_NO_THROW(simulation->instantiatePlatform(platform_file_path));
 
-    // Syntaxic sugar
-    auto compute = "ComputeHost";
-    auto simple_storage0 = "SimpleStorageHost0";
-    auto simple_storage1 = "SimpleStorageHost1";
-    auto compound_storage = "CompoundStorageHost";
-
     // Create a Compute Service
     ASSERT_NO_THROW(
             compute_service = simulation->add(
-                    new wrench::BareMetalComputeService(compute,
-                                                        {std::make_pair(compute, std::make_tuple(wrench::ComputeService::ALL_CORES,
+                    new wrench::BareMetalComputeService("ComputeHost",
+                                                        {std::make_pair("ComputeHost", std::make_tuple(wrench::ComputeService::ALL_CORES,
                                                                                                  wrench::ComputeService::ALL_RAM))},
                                                         {})));
 
     // Create some simple storage services
     // Unbufferized
-    ASSERT_NO_THROW(simple_storage_service_100 = simulation->add(
-                            wrench::SimpleStorageService::createSimpleStorageService(simple_storage0, {"/disk100"},
+    ASSERT_NO_THROW(simple_storage_service_100_0 = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost0", {"/disk100"},
                                                                                      {}, {})));
     // Bufferized
-    ASSERT_NO_THROW(simple_storage_service_510 = simulation->add(
-                            wrench::SimpleStorageService::createSimpleStorageService(simple_storage1, {"/disk510"},
+    ASSERT_NO_THROW(simple_storage_service_510_1 = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost1", {"/disk510"},
                                                                                      {{wrench::SimpleStorageServiceProperty::BUFFER_SIZE, "1000000"}}, {})));
 
     // Fail to create a Compound Storage Service (no storage services provided)
     ASSERT_THROW(compound_storage_service = simulation->add(
-                         new wrench::CompoundStorageService(compound_storage, {})),
+                         new wrench::CompoundStorageService("CompoundStorageHost", {})),
                  std::invalid_argument);
 
     // Fail to create a Compound Storage Service (one of the storage service is just a nullptr)
     ASSERT_THROW(compound_storage_service = simulation->add(
-                         new wrench::CompoundStorageService(compound_storage, {simple_storage_service_1000, simple_storage_service_100})),
+                         new wrench::CompoundStorageService("CompoundStorageHost", {simple_storage_service_1000_0, simple_storage_service_100_0})),
                  std::invalid_argument);
 
     // Create a valid Compound Storage Service, without user provided callback (no intercept capabilities)
     ASSERT_NO_THROW(compound_storage_service = simulation->add(
-                            new wrench::CompoundStorageService(compound_storage, {simple_storage_service_100, simple_storage_service_510})));
+                            new wrench::CompoundStorageService("CompoundStorageHost", 
+                            {simple_storage_service_100_0, simple_storage_service_510_1}, 
+                            {{wrench::CompoundStorageServiceProperty::MAX_ALLOCATION_CHUNK_SIZE, "100"}})));
 
     // Create a Controler
     std::shared_ptr<wrench::ExecutionController> wms = nullptr;
     ASSERT_NO_THROW(wms = simulation->add(
-                            new CompoundStorageServiceBasicFunctionalityTestCtrl(this, compound_storage)));
+                            new CompoundStorageServiceBasicFunctionalityTestCtrl(this, "CompoundStorageHost")));
 
     // A bogus staging (can't use CompoundStorageService for staging)
     ASSERT_THROW(simulation->stageFile(file_10, compound_storage_service), std::invalid_argument);
 
     // Tun the simulation
-    ASSERT_NO_THROW(simulation->launch());
-
-    for (int i = 0; i < argc; i++)
-        free(argv[i]);
-    free(argv);
-}
-
-
-/**********************************************************************/
-/**  BASIC INTERCEPT FUNCTIONALITY SIMULATION TEST                   **/
-/**********************************************************************/
-
-class CompoundStorageServiceInterceptFunctionalityTestCtrl : public wrench::ExecutionController {
-
-public:
-    CompoundStorageServiceInterceptFunctionalityTestCtrl(CompoundStorageServiceFunctionalTest *test,
-                                                         std::string hostname) : wrench::ExecutionController(hostname, "test"), test(test) {
-    }
-
-private:
-    CompoundStorageServiceFunctionalTest *test;
-
-    int main() override {
-
-        std::vector<std::shared_ptr<wrench::Action>> actions;
-
-        // Create a job, and test that messages are correctly forwarded from the css to the underlying storage services
-        auto job_manager = this->createJobManager();
-        auto job1 = job_manager->createCompoundJob("job1");
-
-        wrench::StorageService::createFileAtLocation(wrench::FileLocation::LOCATION(test->simple_storage_service_1000, "/disk1000/", test->file_500));
-
-        // Doing a plain file copy just for kicks
-        wrench::StorageService::copyFile(wrench::FileLocation::LOCATION(test->simple_storage_service_1000, "/disk1000/", test->file_500),
-                                         wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500));
-
-        // Copy from buffered simple storage to CSS (which uses a non-buffered simplestorage service)
-        auto fileCopyActionSS_CSS = job1->addFileCopyAction(
-                "fileCopySrcBufDstCSSNBuff",
-                wrench::FileLocation::LOCATION(test->simple_storage_service_1000, "/disk1000/", test->file_500),
-                wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500));
-        actions.push_back(fileCopyActionSS_CSS);
-
-        // Copy back from CSS (using non-buff SS) to some other place in a bufferized SimpleStorageService
-        auto fileCopyActionCSS_SS = job1->addFileCopyAction(
-                "fileCopySrcCSSNBuffDstBufSS",
-                wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500),
-                wrench::FileLocation::LOCATION(test->simple_storage_service_1000, "/disk1000/copy_from_css/", test->file_500));
-        job1->addActionDependency(fileCopyActionSS_CSS, fileCopyActionCSS_SS);
-        actions.push_back(fileCopyActionCSS_SS);
-
-        // Reading from CSS (previously copied file)
-        auto fileReadAction = job1->addFileReadAction("fileRead1", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500));
-        job1->addActionDependency(fileCopyActionCSS_SS, fileReadAction);
-        actions.push_back(fileReadAction);
-
-        // Write another file to the CSS
-        auto fileWriteAction = job1->addFileWriteAction("fileWrite1", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_10));
-        job1->addActionDependency(fileReadAction, fileWriteAction);
-        actions.push_back(fileWriteAction);
-
-        // Read the file directly from underlying storage service (in this case we know the file will be on simple_storage_service_510, disk 100)
-        auto readWrittenFile = job1->addFileReadAction("directReadFile", wrench::FileLocation::LOCATION(test->simple_storage_service_510, "/disk510/", test->file_10));
-        job1->addActionDependency(fileWriteAction, readWrittenFile);
-        actions.push_back(readWrittenFile);
-
-        // Read it as well through the CSS
-        auto readWrittenFile2 = job1->addFileReadAction("directReadFile2", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_10));
-        job1->addActionDependency(fileWriteAction, readWrittenFile2);
-        actions.push_back(readWrittenFile2);
-
-        // Delete file from CSS
-        auto fileDeleteAction = job1->addFileDeleteAction("fileDelete", wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_10));
-        job1->addActionDependency(readWrittenFile, fileDeleteAction);
-        job1->addActionDependency(readWrittenFile2, fileDeleteAction);
-        actions.push_back(fileDeleteAction);
-
-        job_manager->submitJob(job1, test->compute_service, {});
-
-        std::shared_ptr<wrench::ExecutionEvent> event = this->waitForNextEvent();
-
-        //        for (auto const &action : job1->getActions()) {
-        //            std::cerr << " - " << action->getName() << ": " << action->getStateAsString() << "\n";
-        //            std::cerr << "     " << (action->getFailureCause() ? action->getFailureCause()->toString() : "") << "\n";
-        //        }
-
-        if (not std::dynamic_pointer_cast<wrench::CompoundJobCompletedEvent>(event)) {
-            throw std::runtime_error("Unexpected workflow execution event: " + event->toString());
-        }
-
-        if (job1->getState() != wrench::CompoundJob::State::COMPLETED) {
-            throw std::runtime_error("Unexpected job state: " + job1->getStateAsString());
-        }
-
-        for (auto const &a: actions) {
-            if (a->getState() != wrench::Action::State::COMPLETED) {
-                throw std::runtime_error("One of the actions did not complete");
-            }
-        }
-
-
-        // lookup a deleted file
-        if (wrench::StorageService::lookupFileAtLocation(wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_100))) {
-            throw runtime_error("A file supposed to be deleted (on CSS) was not.");
-        }
-
-        // Check that file copy worked
-        auto file_500_designated_loc = test->compound_storage_service->lookupFileLocation(test->file_500);
-        if (!file_500_designated_loc) {
-            throw std::runtime_error("Should have been able to lookup file_500 through CSS");
-        } else if (file_500_designated_loc->getPath() != "/") {// TODO: HENRI CHANGED THIS TO "/" which is the logical path (used to say "/diskXXX/" which is physical)
-            throw std::runtime_error("file_500 copy through CSS is not where it should be (got path: " + file_500_designated_loc->getPath());
-        }
-
-        return 0;
-    }
-};
-
-TEST_F(CompoundStorageServiceFunctionalTest, BasicInterceptFunctionality) {
-    DO_TEST_WITH_FORK(do_BasicInterceptFunctionality_test);
-}
-
-/* For testing purpose, dummy StorageSelectionStrategyCallback */
-std::shared_ptr<wrench::FileLocation> defaultStorageServiceSelection(
-        const std::shared_ptr<wrench::DataFile> &file,
-        const std::set<std::shared_ptr<wrench::StorageService>> &resources,
-        const std::map<std::shared_ptr<wrench::DataFile>, std::shared_ptr<wrench::FileLocation>> &mapping) {
-
-    auto capacity_req = file->getSize();
-
-    std::shared_ptr<wrench::FileLocation> designated_location = nullptr;
-
-    for (const auto &storage_service: resources) {
-
-        auto free_space = storage_service->getTotalFreeSpace();
-        if (free_space >= capacity_req) {
-            designated_location = wrench::FileLocation::LOCATION(storage_service, file);// TODO: MAJOR CHANGE
-            break;
-        }
-        //        for (const auto &free_space_entry : free_space) {
-        //            if (free_space_entry.second >= capacity_req) {
-        //                designated_location = wrench::FileLocation::LOCATION(storage_service, free_space_entry.first, file);
-        //                break;
-        //            }
-        //        }
-    }
-
-    return designated_location;
-}
-
-void CompoundStorageServiceFunctionalTest::do_BasicInterceptFunctionality_test() {
-
-    // Create and initialize a simulation
-    auto simulation = wrench::Simulation::createSimulation();
-    // xbt_log_control_set("ker_engine.thres:debug");
-    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
-    // xbt_log_control_set("wrench_core_compound_storage_system.thresh:debug");
-    // xbt_log_control_set("wrench_core_file_transfer_thread.thres:info");
-    // xbt_log_control_set("wrench_core_storage_service.thres:info");
-
-    int argc = 1;
-    char **argv = (char **) calloc(argc, sizeof(char *));
-    argv[0] = strdup("unit_test");
-    //    argv[1] = strdup("--wrench-full-log");
-    //    argv[2] = strdup("--log=wrench_core_mailbox.t=debug");
-
-    ASSERT_NO_THROW(simulation->init(&argc, argv));
-
-    // Setting up the platform
-    ASSERT_NO_THROW(simulation->instantiatePlatform(platform_file_path));
-
-    // Get a hostname
-    auto compute = "ComputeHost";
-    auto simple_storage0 = "SimpleStorageHost0";
-    auto simple_storage1 = "SimpleStorageHost1";
-    auto compound_storage = "CompoundStorageHost";
-
-    // Create a Compute Service
-    ASSERT_NO_THROW(
-            compute_service = simulation->add(
-                    new wrench::BareMetalComputeService(compute,
-                                                        {std::make_pair(compute, std::make_tuple(wrench::ComputeService::ALL_CORES,
-                                                                                                 wrench::ComputeService::ALL_RAM))},
-                                                        {})));
-
-    // Create some simple storage services
-    // Bufferized
-    ASSERT_NO_THROW(simple_storage_service_1000 = simulation->add(
-                            wrench::SimpleStorageService::createSimpleStorageService(simple_storage0, {"/disk1000"},
-                                                                                     {{wrench::SimpleStorageServiceProperty::BUFFER_SIZE, "1000000"}}, {})));
-
-    // Non-bufferized
-    ASSERT_NO_THROW(simple_storage_service_100 = simulation->add(
-                            wrench::SimpleStorageService::createSimpleStorageService(simple_storage0, {"/disk100"},
-                                                                                     {}, {})));
-
-    // Non-bufferized
-    //    ASSERT_NO_THROW(simple_storage_service_510 = simulation->add(
-    //            wrench::SimpleStorageService::createSimpleStorageService(simple_storage1, {"/disk100", "/disk510"},
-    //                                                                     {}, {})));
-    ASSERT_NO_THROW(simple_storage_service_510 = simulation->add(
-                            wrench::SimpleStorageService::createSimpleStorageService(simple_storage1, {"/disk510"},
-                                                                                     {}, {})));
-
-    // Create a valid Compound Storage Service (using a non-bufferized storage service in this case) with a user-provided callback
-    ASSERT_NO_THROW(compound_storage_service = simulation->add(
-                            new wrench::CompoundStorageService(compound_storage, {simple_storage_service_510}, defaultStorageServiceSelection)));
-
-    // Create a Controller
-    std::shared_ptr<wrench::ExecutionController> wms = nullptr;
-    ASSERT_NO_THROW(wms = simulation->add(
-                            new CompoundStorageServiceInterceptFunctionalityTestCtrl(this, compute)));
-
-    // Running a "run a single task1" simulation
     ASSERT_NO_THROW(simulation->launch());
 
     for (int i = 0; i < argc; i++)
@@ -567,19 +1074,26 @@ private:
         auto fileCopyActionCSS_SS = jobCopyError->addFileCopyAction(
                 "fileCopySrcCSS_DstSS",
                 wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_500),
-                wrench::FileLocation::LOCATION(test->simple_storage_service_1000, "/disk1000/copy_from_css/", test->file_500));
+                wrench::FileLocation::LOCATION(test->simple_storage_service_1000_0, test->file_500));
 
         job_manager->submitJob(jobCopyError, test->compute_service, {});
 
+        // Dirty solution to make all tests run : normally we would stop simulation after the
+        // first error, and wouldn't care about what happens to following jobs, but here we need to
+        // give some time to each job to "properly" fail
+        simulation->sleep(10000);
+
         // 2 - Copy from SS to CSS, using a file that is too big to be allocated
         auto jobCopySizeError = job_manager->createCompoundJob("jobCopySizeError");
-        wrench::StorageService::createFileAtLocation(wrench::FileLocation::LOCATION(test->simple_storage_service_1000, "/disk1000/", test->file_1000));
+        wrench::StorageService::createFileAtLocation(wrench::FileLocation::LOCATION(test->simple_storage_service_1000_0, test->file_1000));
         auto fileCopyActionSS_CSS = jobCopySizeError->addFileCopyAction(
                 "fileCopySrcSS_DstCSS",
-                wrench::FileLocation::LOCATION(test->simple_storage_service_1000, "/disk1000/", test->file_1000),
+                wrench::FileLocation::LOCATION(test->simple_storage_service_1000_0, test->file_1000),
                 wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1000));
 
         job_manager->submitJob(jobCopySizeError, test->compute_service, {});
+
+        simulation->sleep(10000);
 
         // 3 - Read from CSS, using a file that was not written/copied to it beforehand
         auto jobReadError = job_manager->createCompoundJob("jobReadError");
@@ -588,8 +1102,10 @@ private:
                 wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1000));
 
         job_manager->submitJob(jobReadError, test->compute_service, {});
+        
+        simulation->sleep(10000);
 
-        // 4 - Write to CSS, with a file too big to be allocated
+        // 4 - Try to write a file too big on CSS
         auto jobWriteError = job_manager->createCompoundJob("jobWriteError");
         auto fileWriteActionCSS = jobWriteError->addFileReadAction(
                 "fileWriteActionCSS",
@@ -597,49 +1113,52 @@ private:
 
         job_manager->submitJob(jobWriteError, test->compute_service, {});
 
-        // 5 - Write to CSS, with a file too big to be allocated
+        simulation->sleep(10000);
+
+        // 5 - Delete file from CSS, but it's not there
         auto jobDeleteError = job_manager->createCompoundJob("jobDeleteError");
         auto fileDeleteActionCSS = jobDeleteError->addFileReadAction(
                 "fileDeleteActionCSS",
                 wrench::FileLocation::LOCATION(test->compound_storage_service, test->file_1000));
 
         job_manager->submitJob(jobDeleteError, test->compute_service, {});
-
+        
 
         // 1
         this->waitForNextEvent();
         if (!jobCopyError->hasFailed())
-            throw std::runtime_error("Unexpected job state: " + jobCopyError->getStateAsString());
-        if (!std::dynamic_pointer_cast<wrench::NotAllowed>(fileCopyActionCSS_SS->getFailureCause()))
-            throw std::runtime_error("Did not receive a 'NotAllowed' failure cause as expected");
+            throw std::runtime_error("1-Unexpected job state: " + jobCopyError->getStateAsString());
+        if (!std::dynamic_pointer_cast<wrench::FileNotFound>(fileCopyActionCSS_SS->getFailureCause()))
+            throw std::runtime_error("1-Did not receive a 'NotAllowed' failure cause as expected");
 
         // 2
         this->waitForNextEvent();
         if (!jobCopySizeError->hasFailed())
-            throw std::runtime_error("Unexpected job state: " + jobCopySizeError->getStateAsString());
+            throw std::runtime_error("2-Unexpected job state: " + jobCopySizeError->getStateAsString());
         if (!std::dynamic_pointer_cast<wrench::StorageServiceNotEnoughSpace>(fileCopyActionSS_CSS->getFailureCause()))
-            throw std::runtime_error("Did not receive a 'StorageServiceNotEnoughSpace' failure cause as expected");
-
+            throw std::runtime_error("2-Did not receive a 'StorageServiceNotEnoughSpace' failure cause as expected");
+        
         // 3
         this->waitForNextEvent();
         if (!jobReadError->hasFailed())
-            throw std::runtime_error("Unexpected job state: " + jobReadError->getStateAsString());
+            throw std::runtime_error("3-Unexpected job state: " + jobReadError->getStateAsString());
         if (!std::dynamic_pointer_cast<wrench::FileNotFound>(fileReadActionCSS->getFailureCause()))
-            throw std::runtime_error("Did not receive a 'FileNotFound' failure cause as expected");
-
+            throw std::runtime_error("3-Did not receive a 'FileNotFound' failure cause as expected");
+        
         // 4
         this->waitForNextEvent();
         if (!jobWriteError->hasFailed())
-            throw std::runtime_error("Unexpected job state: " + jobWriteError->getStateAsString());
+            throw std::runtime_error("4-Unexpected job state: " + jobWriteError->getStateAsString());
         if (!std::dynamic_pointer_cast<wrench::FileNotFound>(fileWriteActionCSS->getFailureCause()))
-            throw std::runtime_error("Did not receive a 'FileNotFound' failure cause as expected");
+            throw std::runtime_error("4-Did not receive a 'FileNotFound' failure cause as expected");
 
         // 5
         this->waitForNextEvent();
         if (!jobDeleteError->hasFailed())
-            throw std::runtime_error("Unexpected job state: " + jobDeleteError->getStateAsString());
+            throw std::runtime_error("5-Unexpected job state: " + jobDeleteError->getStateAsString());
         if (!std::dynamic_pointer_cast<wrench::FileNotFound>(fileDeleteActionCSS->getFailureCause()))
-            throw std::runtime_error("Did not receive a 'FileNotFound' failure cause as expected");
+            throw std::runtime_error("5-Did not receive a 'FileNotFound' failure cause as expected");
+        
 
         return 0;
     }
@@ -669,45 +1188,43 @@ void CompoundStorageServiceFunctionalTest::do_BasicError_test() {
     // Setting up the platform
     ASSERT_NO_THROW(simulation->instantiatePlatform(platform_file_path));
 
-    // Get a hostname
-    auto compute = "ComputeHost";
-    auto simple_storage0 = "SimpleStorageHost0";
-    auto simple_storage1 = "SimpleStorageHost1";
-    auto compound_storage = "CompoundStorageHost";
-
     // Create a Compute Service
     ASSERT_NO_THROW(
             compute_service = simulation->add(
-                    new wrench::BareMetalComputeService(compute,
-                                                        {std::make_pair(compute, std::make_tuple(wrench::ComputeService::ALL_CORES,
+                    new wrench::BareMetalComputeService("ComputeHost",
+                                                        {std::make_pair("ComputeHost", std::make_tuple(wrench::ComputeService::ALL_CORES,
                                                                                                  wrench::ComputeService::ALL_RAM))},
                                                         {})));
 
     // Create some simple storage services
     // Bufferized
-    ASSERT_NO_THROW(simple_storage_service_1000 = simulation->add(
-                            wrench::SimpleStorageService::createSimpleStorageService(simple_storage0, {"/disk1000"},
+    ASSERT_NO_THROW(simple_storage_service_1000_0 = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost0", {"/disk1000"},
                                                                                      {{wrench::SimpleStorageServiceProperty::BUFFER_SIZE, "1000000"}}, {})));
 
     // Non-bufferized
-    ASSERT_NO_THROW(simple_storage_service_100 = simulation->add(
-                            wrench::SimpleStorageService::createSimpleStorageService(simple_storage0, {"/disk100"},
+    ASSERT_NO_THROW(simple_storage_service_100_0 = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost0", {"/disk100"},
                                                                                      {}, {})));
 
     // Non-bufferized
-    ASSERT_NO_THROW(simple_storage_service_510 = simulation->add(
-                            wrench::SimpleStorageService::createSimpleStorageService(simple_storage1, {"/disk510"},
+    ASSERT_NO_THROW(simple_storage_service_510_1 = simulation->add(
+                            wrench::SimpleStorageService::createSimpleStorageService("SimpleStorageHost1", {"/disk510"},
                                                                                      {}, {})));
 
     // Create a valid Compound Storage Service (using a non-bufferized storage service in this case) with a user-provided callback
     // CAREFUL -> REUSING CALLBACK FROM PREVIOUS TEST
     ASSERT_NO_THROW(compound_storage_service = simulation->add(
-                            new wrench::CompoundStorageService(compound_storage, {simple_storage_service_510}, defaultStorageServiceSelection)));
+                            new wrench::CompoundStorageService(
+                                "CompoundStorageHost", 
+                                {simple_storage_service_510_1}, 
+                                defaultStorageServiceSelection, 
+                                {{wrench::CompoundStorageServiceProperty::MAX_ALLOCATION_CHUNK_SIZE, "100"}})));
 
     // Create a Controller
     std::shared_ptr<wrench::ExecutionController> wms = nullptr;
     ASSERT_NO_THROW(wms = simulation->add(
-                            new CompoundStorageServiceErrorTestCtrl(this, compute)));
+                            new CompoundStorageServiceErrorTestCtrl(this, "CompoundStorageHost")));
 
     // Running a "run a single task1" simulation
     ASSERT_NO_THROW(simulation->launch());


### PR DESCRIPTION
This PR  updates the CompoundStorageService, along with a few minor updates in StorageService and SimpleStorageService, in order to accommodate the new features and add a small function to get free space on a StorageService with no simulated cost (for tracing purpose).

The CompoundStorageService (CSS) doesn't intercept IO-related actions requests anymore, but rather overrides a set of methods from StorageService, allowing it to process IO-related actions in its own way (masking the striping of some files and how actions are actually distributed to the inner SimpleStorageServices of the CSS).
New messages for the CSS are also introduced (CompoundStorageAllocation[Request|Answer]Message and CompoundStorageLookup[Request|Answer]Message) in order to handle the allocation decisions (these messages are sent from the CSS to itself).

CSS tests have been updated accordingly.