### PR TITLE
[CompoundStorage] Fixing a broken stop condition 

### DIFF
--- a/src/wrench/services/storage/compound/CompoundStorageService.cpp
+++ b/src/wrench/services/storage/compound/CompoundStorageService.cpp
@@ -918,7 +918,7 @@ namespace wrench {
                 for (auto const &dwmb: msg->data_write_commport_and_bytes) {
                     // Bufferized
                     sg_size_t remaining = dwmb.second;
-                    while (remaining - buffer_size > 0) {
+                    while (remaining > buffer_size) {
                         dwmb.first->dputMessage(new StorageServiceFileContentChunkMessage(
                                 file, buffer_size, false));
                         remaining -= buffer_size;


### PR DESCRIPTION
If think I was using a duplicated piece of code from StorageService::writeFile(...) inside CompoundStorageService::writeFile(...). A variable seems to have gone from signed to unsigned type a few months ago and it breaks the stopping condition in the for loop. This was apparently fixed right away in the StorageService, this commit just applies the same fix in the CSS.